### PR TITLE
Wall of Skin fight improvements

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -4302,6 +4302,23 @@ boolean L13_towerNSTower()
 		{
 			equip($item[astral shirt]);
 		}
+		else if(item_amount($item[Unfortunato's foolscap]) > 0)
+		{
+			equip($item[Unfortunato's foolscap]);
+		}
+		else if(item_amount($item[cigar box turtle]) > 0)
+		{
+			use(1, $item[cigar box turtle]);
+		}
+		else if(have_effect($effect[damage.enh]) == 0)
+		{
+			int enhances = sl_sourceTerminalEnhanceLeft();
+			if(enhances > 0)
+			{
+				sl_sourceTerminalEnhance("damage");
+			}
+		}
+
 		if((my_class() == $class[Turtle Tamer]) && (item_amount($item[Shocked Shell]) > 0))
 		{
 			equip($slot[shirt], $item[Shocked Shell]);
@@ -6400,8 +6417,8 @@ boolean LX_spookyravenSecond()
 		}
 		if(item_amount($item[Lady Spookyraven\'s Dancing Shoes]) == 0)
 		{
- 			set_property("louvreGoal", "7");
- 			set_property("louvreDesiredGoal", "7");
+			set_property("louvreGoal", "7");
+			set_property("louvreDesiredGoal", "7");
 			print("Spookyraven: Gallery", "blue");
 
 			sl_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
@@ -12412,7 +12429,7 @@ boolean L9_chasmBuild()
 
 		ccAdv(1, $location[The Smut Orc Logging Camp]);
 
- 		if(item_amount($item[Smut Orc Keepsake Box]) > 0)
+		if(item_amount($item[Smut Orc Keepsake Box]) > 0)
 		{
 			if(sl_my_path() != "G-Lover")
 			{
@@ -13713,7 +13730,7 @@ void print_header()
 		print("Still flyering: " + get_property("flyeredML"), "blue");
 	}
 	print("Encounter: " + combat_rate_modifier() + "   Exp Bonus: " + experience_bonus(), "blue");
-	print("Meat Drop: " + meat_drop_modifier() + "   Item Drop: " + item_drop_modifier(), "blue");
+	print("Meat Drop: " + meat_drop_modifier() + "	 Item Drop: " + item_drop_modifier(), "blue");
 	print("HP: " + my_hp() + "/" + my_maxhp() + ", MP: " + my_mp() + "/" + my_maxmp(), "blue");
 	print("Tummy: " + my_fullness() + "/" + fullness_limit() + " Liver: " + my_inebriety() + "/" + inebriety_limit() + " Spleen: " + my_spleen_use() + "/" + spleen_limit(), "blue");
 	print("ML: " + monster_level_adjustment() + " control: " + current_mcd(), "blue");

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -335,9 +335,19 @@ string sl_combatHandler(int round, string opp, string text)
 			return "skill " + $skill[Sauceshell];
 		}
 
-		if(have_equipped($item[Astral Shirt]))
-		{
-			if(sl_have_skill($skill[headbutt]) && (my_mp() >= 3))
+		if(sl_have_skill($skill[Belch the Rainbow]) && (my_mp() >= mp_cost($skill[Belch the Rainbow]))) {
+			return "skill " + $skill[Belch the Rainbow];
+		}
+
+		int sources = 0;
+		foreach damage in $strings[Cold Damage, Hot Damage, Sleaze Damage, Spooky Damage, Stench Damage] {
+			if(numeric_modifier(damage) > 0) {
+				sources += 1;
+			}
+		}
+
+		if (sources >= 4) {
+			if(sl_have_skill($skill[headbutt]) && (my_mp() >= mp_cost($skill[Headbutt])))
 			{
 				return "skill " + $skill[Headbutt];
 			}
@@ -345,10 +355,6 @@ string sl_combatHandler(int round, string opp, string text)
 			{
 				return "skill " + $skill[Clobber];
 			}
-		}
-		if(sl_have_skill($skill[Belch the Rainbow]) && (my_mp() >= mp_cost($skill[Belch the Rainbow])))
-		{
-			return "skill " + $skill[Belch the Rainbow];
 		}
 		return "attack with weapon";
 	}


### PR DESCRIPTION
Various improvements to the "stack up some prismatic damage and hit it until it dies" plan for killing the Wall of Skin.

* Instead of relying on the Astral Shirt for prismatic damage, use any number of quick and easy sources. This could be replaced by a call to the maximizer.
* Code in cc_combat.ash to check if we have enough prismatic damage to justify using combat skills with better chance of hitting.
* If we have Belch the Rainbow, we should ignore the above and just use Belch the Rainbow. Full stop.

There also seem to be some whitespace changes from my autolinter that snuck in. I would encourage this project to get an autolinter working and make it run as a pre-commit hook.