### PR TITLE
Reserve some sausages for MP restoration

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -583,6 +583,7 @@ int sl_sausageMeatPasteNeededForSausage(int numSaus); // Defined in sl_ascend/sl
 int sl_sausageFightsToday(); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageGrind(int numSaus); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageGrind(int numSaus, boolean failIfCantMakeAll); // Defined in sl_ascend/sl_mr2019.ash
+boolean sl_sausageEatEmUp(int maximumToEat); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageEatEmUp(); // Defined in sl_ascend/sl_mr2019.ash
 boolean getSpaceJelly();									//Defined in sl_ascend/sl_mr2017.ash
 int horseCost();											//Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_mr2019.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2019.ash
@@ -87,7 +87,16 @@ boolean sl_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 
 boolean sl_sausageEatEmUp(int maxToEat)
 {
+	// if maxToEat is 0, eat as many sausages as possible while respecting the reserve
 	int sausage_reserve_size = 3;
+	if (maxToEat == 0)
+	{
+		maxToEat = sl_sausageLeftToday();
+	}
+	else
+	{
+		sausage_reserve_size = 0;
+	}
 
 	if(item_amount($item[magical sausage]) <= sausage_reserve_size || get_property("sl_saveMagicalSausage").to_boolean())
 		return false;
@@ -125,5 +134,5 @@ boolean sl_sausageEatEmUp(int maxToEat)
 }
 
 boolean sl_sausageEatEmUp() {
-	return sl_sausageEatEmUp(sl_sausageLeftToday());
+	return sl_sausageEatEmUp(0);
 }

--- a/RELEASE/scripts/sl_ascend/sl_mr2019.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2019.ash
@@ -85,9 +85,11 @@ boolean sl_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 	return true;
 }
 
-boolean sl_sausageEatEmUp()
+boolean sl_sausageEatEmUp(int maxToEat)
 {
-	if(item_amount($item[magical sausage]) == 0 || get_property("sl_saveMagicalSausage").to_boolean())
+	int sausage_reserve_size = 3;
+
+	if(item_amount($item[magical sausage]) <= sausage_reserve_size || get_property("sl_saveMagicalSausage").to_boolean())
 		return false;
 
 	if(sl_sausageLeftToday() <= 0)
@@ -98,7 +100,7 @@ boolean sl_sausageEatEmUp()
 	maximize("mp,-tie", false);
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...
 	// but meh.
-	while(item_amount($item[magical sausage]) > 0)
+	while(maxToEat > 0 && item_amount($item[magical sausage]) > sausage_reserve_size)
 	{
 		if(sl_sausageLeftToday() <= 0)
 			break;
@@ -111,6 +113,7 @@ boolean sl_sausageEatEmUp()
 			print("Somehow failed to eat a sausage! What??", "red");
 			return false;
 		}
+		maxToEat--;
 	}
 
 	// burn any mp that'll go away when equipment switches back
@@ -119,4 +122,8 @@ boolean sl_sausageEatEmUp()
 		cli_execute("burn " + mpToBurn);
 
 	return true;
+}
+
+boolean sl_sausageEatEmUp() {
+	return sl_sausageEatEmUp(sl_sausageLeftToday());
 }

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -1966,6 +1966,12 @@ boolean acquireMP(int goal, boolean buyIt)
 		return false;
 	}
 
+	// Sausages restore 999MP, this is a pretty arbitrary cutoff but it should reduce pain
+	if (my_maxmp() - my_mp() > 300)
+	{
+		sl_sausageEatEmUp(1);
+	}
+
 	item[int] recovers = List($items[Holy Spring Water, Spirit Beer, Sacramental Wine, Magical Mystery Juice, Black Cherry Soda, Doc Galaktik\'s Invigorating Tonic, Carbonated Soy Milk, Natural Fennel Soda, Grogpagne, Bottle Of Monsieur Bubble, Tiny House, Marquis De Poivre Soda, Cloaca-Cola, Phonics Down, Psychokinetic Energy Blob]);
 	int at = 0;
 	while((at < count(recovers)) && (my_mp() < goal))


### PR DESCRIPTION
Reserve a small number of sausages (3) for MP restoration.

Regular sausage consumption won't dig into the reserve, the reserve is only used when acquireMP() is called and we've got a *lot* of extra headroom to restore MP.

Context at https://github.com/soolar/sl_ascend/issues/15