### PR TITLE
HCCS fixes

### DIFF
--- a/RELEASE/relay/sl_ascend_settings.txt
+++ b/RELEASE/relay/sl_ascend_settings.txt
@@ -47,5 +47,7 @@
 47	sl_hideAdultery	boolean	ANY	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
 48	sl_slowSteelOrgan	boolean	ANY	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
 49	sl_saveSausage	boolean	ANY	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-50	sl_saveMagicalSausage	boolean	ANY	When true, don't eat magical sausage, so you can save them up for aftercore.
-51	sl_beta_test	boolean	ANY	Occasionally I might need to make big changes, but not want to do so without some broader testing. If you're a kind, generous soul, you can test these features by setting this to true! sl_beta_test will be mentioned in the change logs whenever there is something to test, and mentioned again when that feature stops being a beta feature.
+50	sl_saveVintage	boolean	ANY	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+51	sl_saveMagicalSausage	boolean	ANY	When true, don't eat magical sausage, so you can save them up for aftercore.
+52	sl_beta_test	boolean	ANY	Occasionally I might need to make big changes, but not want to do so without some broader testing. If you're a kind, generous soul, you can test these features by setting this to true! sl_beta_test will be mentioned in the change logs whenever there is something to test, and mentioned again when that feature stops being a beta feature.
+

--- a/RELEASE/scripts/sl_ascend/sl_adventure.ash
+++ b/RELEASE/scripts/sl_ascend/sl_adventure.ash
@@ -105,6 +105,10 @@ boolean ccAdvBypass(int urlGetFlags, string[int] url, location loc, string optio
 	set_property("nextAdventure", loc);
 	cli_execute("presool");
 #	handlePreAdventure(loc);
+	if(option == "")
+	{
+		option = "sl_combatHandler";
+	}
 	if(my_class() == $class[Ed])
 	{
 		ed_preAdv(1, loc, option);

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -834,8 +834,8 @@ void handlePreAdventure(location place);					//Defined in presool.ash
 
 void handlePostAdventure();									//Defined in postsool.ash
 
-void handleKingLiberation();								//Defined in kingcheese.ash
-boolean pullPVPJunk();										//Defined in kingcheese.ash
+void handleKingLiberation();								//Defined in kingsool.ash
+boolean pullPVPJunk();										//Defined in kingsool.ash
 
 boolean sl_acquireKeycards();								//Defined in sl_ascend/sl_aftercore.ash
 boolean sl_aftercore();										//Defined in sl_ascend/sl_aftercore.ash

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -460,10 +460,10 @@ boolean LA_cs_communityService()
 			if((internalQuestStatus("questG07Myst") == 1) || (internalQuestStatus("questG08Moxie") == 1) || (internalQuestStatus("questG09Muscle") == 1))
 			{
 				handleBarrelFullOfBarrels(true);
+				visit_url("guild.php?place=challenge");
 				if(knoll_available())
 				{
 					while(LX_bitchinMeatcar());
-					visit_url("guild.php?place=challenge");
 					visit_url("guild.php?place=paco");
 					visit_url("guild.php?place=paco");
 					visit_url("guild.php?place=paco");
@@ -1367,7 +1367,7 @@ boolean LA_cs_communityService()
 			{
 				if(do_cs_quest(30))
 				{
-					cli_execute("call kingcheese");
+					cli_execute("call kingsool");
 					return true;
 				}
 				else
@@ -2098,7 +2098,7 @@ boolean LA_cs_communityService()
 						}
 
 					}
-					else
+					else if ((item_amount($item[Vintage Smart Drink]) > 0) && !get_property("sl_saveVintage").to_boolean())
 					{
 						shrugAT($effect[Ode to Booze]);
 						buffMaintain($effect[Ode to Booze], 50, 1, 10);
@@ -2494,7 +2494,7 @@ boolean LA_cs_communityService()
 			}
 			asdonBuff($effect[Driving Stealthily]);
 
-			if(have_familiar($familiar[Disgeist]))
+			if(!is100FamiliarRun($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
 			{
 				# Need 37-41 pounds to save 3 turns. (probably 40)
 				# 74 does not save 6 but 79 does.

--- a/RELEASE/scripts/sl_ascend/sl_deprecation.ash
+++ b/RELEASE/scripts/sl_ascend/sl_deprecation.ash
@@ -183,7 +183,7 @@ boolean settingFixer()
 
 	if(get_property("kingLiberatedScript") == "scripts/kingLiberated.ash")
 	{
-		set_property("kingLiberatedScript", "kingcheese.ash");
+		set_property("kingLiberatedScript", "kingsool.ash");
 	}
 	if(get_property("afterAdventureScript") == "scripts/postadventure.ash")
 	{

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2374,7 +2374,7 @@ boolean isFreeMonster(monster mon)
 
 	boolean[monster] voting = $monsters[Angry Ghost, Annoyed Snake, Government Bureaucrat, Slime Blob, Terrible Mutant];
 
-	boolean[monster] other = $monsters[giant rubber spider, God Lobster, lynyrd, time-spinner prank, Travoltron];
+	boolean[monster] other = $monsters[giant rubber spider, God Lobster, lynyrd, time-spinner prank, Travoltron, sausage goblin];
 
 	//boolean[monster] protonGhosts: See isProtonGhost, we want to detect these separately as well so we\'ll functionalize it here.
 


### PR DESCRIPTION
Add setting to save Vintage Smart Drink
Fix aborting when fighting seals
Fix remaining references of kingcheese -> kingsool
Fix unlocking guild store of knoll isn't available
Don't use Disgeist if in a 100% familiar run
Sausage goblin is a free fight