### PR TITLE
Fix infinite looping Groar in Dark Gyffte

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12950,7 +12950,7 @@ boolean L8_trapperGroar()
 		}
 	}
 
-	if((item_amount($item[Groar\'s Fur]) > 0) || (item_amount($item[Winged Yeti Fur]) > 0))
+	if((item_amount($item[Groar\'s Fur]) > 0) || (item_amount($item[Winged Yeti Fur]) > 0) || (internalQuestStatus("questL08Trapper") == 5))
 	{
 		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
 		if(item_amount($item[Dense Meat Stack]) >= 5)


### PR DESCRIPTION
Turns out fighting a Dark Gyffte boss at the Icy Peak doesn't give us Groar fur, so this check was failing. I *think* the other terms in this are now redundant, but I'm leaving them in because why break it?