### PR TITLE
Always stay in run if not a standard class

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -4083,7 +4083,7 @@ boolean L13_towerNSFinal()
 				abort("User wanted to stay in run (sl_stayInRun), we are done.");
 			}
 
-			if($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Gelatinous Noob] contains my_class())
+			if(!($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class()))
 			{
 				set_property("sl_disableAdventureHandling", false);
 				if(get_property("sl_sorceress") == "finished")


### PR DESCRIPTION
Check that my_class() is not a standard class instead of checking against a list of classes that would need to be updated.