### PR TITLE
If FantasyRealm available, avoid Daily Dungeon

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -10704,6 +10704,10 @@ boolean LX_phatLootToken()
 	{
 		return true;
 	}
+	if(fantasyRealmAvailable() && get_property("sl_sorceress") != "door")
+	{
+		return false;
+	}
 
 	if((!possessEquipment($item[Ring of Detect Boring Doors]) || (item_amount($item[Eleven-Foot Pole]) == 0) || (item_amount($item[Pick-O-Matic Lockpicks]) == 0)) && sl_have_familiar($familiar[Gelatinous Cubeling]))
 	{

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -545,6 +545,7 @@ boolean godLobsterCombat(item it);							//Defined in sl_ascend/sl_mr2018.ash
 boolean godLobsterCombat(item it, int goal);				//Defined in sl_ascend/sl_mr2018.ash
 boolean godLobsterCombat(item it, int goal, string option);	//Defined in sl_ascend/sl_mr2018.ash
 boolean fantasyRealmToken();								//Defined in sl_ascend/sl_mr2018.ash
+boolean fantasyRealmAvailable();							//Defined in sl_ascend/sl_mr2018.ash
 boolean songboomSetting(string goal);						//Defined in sl_ascend/sl_mr2018.ash
 boolean songboomSetting(int choice);						//Defined in sl_ascend/sl_mr2018.ash
 boolean fightClubNap();										//Defined in sl_ascend/sl_mr2018.ash

--- a/RELEASE/scripts/sl_ascend/sl_mr2018.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2018.ash
@@ -242,6 +242,18 @@ boolean godLobsterCombat(item it, int goal, string option)
 	return true;
 }
 
+boolean fantasyRealmAvailable()
+{
+	if(!is_unrestricted($item[FantasyRealm membership packet]))
+	{
+		return false;
+	}
+	if((get_property("frAlways").to_boolean() || get_property("_frToday").to_boolean()))
+	{
+		return true;
+	}
+	return false;
+}
 
 boolean fantasyRealmToken()
 {


### PR DESCRIPTION
Unless, of course, we're at the Sorceress's door and are missing tokens, in which case DEFINITELY do the Daily Dungeon ASAP.

This saves turns in most 3-day Standard runs: previously we would do FR and DD on day 1, then FR on day 2. It's more turn-efficient to do FR on days 1, 2, 3.

For 2-day runs, this is not a regression, it just moves doing the Daily Dungeon from day 1 to 2 (instead of 1: FR, DD, 2: FR, we do 1: FR, 2: FR, DD).