### PR TITLE
Better Nuns, better Boombox usage

### DIFF
--- a/BUILD/equipment/weapon.dat
+++ b/BUILD/equipment/weapon.dat
@@ -63,6 +63,9 @@ knife	mainstat:Moxie
 Thor's Pliers
 # Nice ultra rare you got there
 The Nuge's favorite crossbow	mainstat:Moxie
+# Vampyres are a Mysticality class that sometimes can't use spells. Ugh.
+disco ball	class:Vampyre;skill:Sinister Charm;effect:Bats Form;!skill:Piercing Gaze
+disco ball	class:Vampyre;skill:Sinister Charm;effect:Wolf Form;!skill:Savage Bite
 # Some more stuff. It's okay, I guess
 The Jokester's Gun	mainstat:Moxie
 world's smallest violin	mainstat:Moxie

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -432,52 +432,55 @@ weapon	48	knife	mainstat:Moxie
 weapon	49	Thor's Pliers
 # Nice ultra rare you got there
 weapon	50	The Nuge's favorite crossbow	mainstat:Moxie
+# Vampyres are a Mysticality class that sometimes can't use spells. Ugh.
+weapon	51	disco ball	class:Vampyre;skill:Sinister Charm;effect:Bats Form;!skill:Piercing Gaze
+weapon	52	disco ball	class:Vampyre;skill:Sinister Charm;effect:Wolf Form;!skill:Savage Bite
 # Some more stuff. It's okay, I guess
-weapon	51	The Jokester's Gun	mainstat:Moxie
-weapon	52	world's smallest violin	mainstat:Moxie
-weapon	53	Frigid Derringer	mainstat:Moxie
-weapon	54	witty rapier	mainstat:Mysticality
-weapon	55	Chopsticks	mainstat:Mysticality
-weapon	56	Oversized Pizza Cutter	mainstat:Mysticality
-weapon	57	Eggbeater	mainstat:Mysticality
-weapon	58	Corn Holder	mainstat:Mysticality
-weapon	59	Dishrag	mainstat:Mysticality
+weapon	53	The Jokester's Gun	mainstat:Moxie
+weapon	54	world's smallest violin	mainstat:Moxie
+weapon	55	Frigid Derringer	mainstat:Moxie
+weapon	56	witty rapier	mainstat:Mysticality
+weapon	57	Chopsticks	mainstat:Mysticality
+weapon	58	Oversized Pizza Cutter	mainstat:Mysticality
+weapon	59	Eggbeater	mainstat:Mysticality
+weapon	60	Corn Holder	mainstat:Mysticality
+weapon	61	Dishrag	mainstat:Mysticality
 # Good knives
-weapon	60	black blade	mainstat:Moxie;skill:Tricky Knifework
-weapon	61	batblade	mainstat:Moxie;skill:Tricky Knifework
-weapon	62	soap knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	63	Saturday Night Special	mainstat:Moxie
+weapon	62	black blade	mainstat:Moxie;skill:Tricky Knifework
+weapon	63	batblade	mainstat:Moxie;skill:Tricky Knifework
+weapon	64	soap knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	65	Saturday Night Special	mainstat:Moxie
 # Knives that are fine
-weapon	64	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
-weapon	65	candy knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	66	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
-weapon	67	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
-weapon	68	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
+weapon	66	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
+weapon	67	candy knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	68	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
+weapon	69	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
+weapon	70	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
 # This stuff is definitely better than garbage
-weapon	69	finger cymbals	mainstat:Moxie
+weapon	71	finger cymbals	mainstat:Moxie
 # The worst knife, but it's still a knife
-weapon	70	boot knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	71	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	72	boot knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	73	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
 # It's not good, but at least it's a ranged weapon that takes one hand
-weapon	72	disco ball	mainstat:Moxie
-weapon	73	stolen accordion	class:Accordion Thief
+weapon	74	disco ball	mainstat:Moxie
+weapon	75	stolen accordion	class:Accordion Thief
 # Some melee weapons
-weapon	74	Rusty Piece Of Rebar
-weapon	75	Octopus's Spade
-weapon	76	Oversized Pipe
-weapon	77	Ghast Iron Cleaver
-weapon	78	Short-Handled Mop
-weapon	79	Spectral Axe
-weapon	80	Antique Machete
-weapon	81	red-hot sausage fork
+weapon	76	Rusty Piece Of Rebar
+weapon	77	Octopus's Spade
+weapon	78	Oversized Pipe
+weapon	79	Ghast Iron Cleaver
+weapon	80	Short-Handled Mop
+weapon	81	Spectral Axe
+weapon	82	Antique Machete
+weapon	83	red-hot sausage fork
 # Almost absolute garbage
-weapon	82	Skeleton Bone
-weapon	83	Corn Holder
-weapon	84	Knob Goblin Scimitar
-weapon	85	Knob Goblin Tongs
+weapon	84	Skeleton Bone
+weapon	85	Corn Holder
+weapon	86	Knob Goblin Scimitar
+weapon	87	Knob Goblin Tongs
 # Absolute garbage, but better than nothing, probably?
-weapon	86	Turtle Totem	class:Turtle Tamer
-weapon	87	Saucepan	class:Sauceror
-weapon	88	Pasta Spoon	class:Pastamancer
+weapon	88	Turtle Totem	class:Turtle Tamer
+weapon	89	Saucepan	class:Sauceror
+weapon	90	Pasta Spoon	class:Pastamancer
 # I probably missed some stuff from the old weapon handling but c'est la vie
 

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -387,13 +387,15 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 #5		Plush Elephant		LOV Elephant (Shield, DR+10)
 #6		Toast? Only with Space Jellyfish?
 #7		Nothing
-
 	if(enforcer || engineer || equivocator)
 	{
 		set_property("sl_disableAdventureHandling", false);
 		cli_execute("postsool");
 	}
-
+	if(item_amount($item[LOV Extraterrestrial Chocolate]) > 0)
+	{
+		use(1, $item[LOV Extraterrestrial Chocolate]);
+	}
 	return true;
 }
 

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -4449,6 +4449,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Drenched With Filth]:			useItem = $item[Concentrated Garbage Juice];	break;
 	case $effect[Drescher\'s Annoying Noise]:	useSkill = $skill[Drescher\'s Annoying Noise];	break;
 	case $effect[Drunk and Avuncular]:			useItem = $item[Drunk Uncles Holo-Record];		break;
+	case $effect[Eagle Eyes]:					useItem = $item[eagle feather];					break;
 	case $effect[Ear Winds]:					useSkill = $skill[Flappy Ears];					break;
 	case $effect[Eau D\'enmity]:				useItem = $item[Perfume of Prejudice];			break;
 	case $effect[Eau de Tortue]:				useItem = $item[Turtle Pheromones];				break;


### PR DESCRIPTION
Plus other miscellaneous fixes. Full changelog:
* [LOV] Consume LOV chocolate
* Lynyrd Snare uses are Zeppelin Protestor advs
* [vampyre] Do bedtime when not full if out of blood bags
* Use Eagle Feather for filthworms
* [boombox] Use Boombox at Gremlins (DR) and Nuns (meat)
* Use Body Spradium at Nuns
* Use maximizer call for nuns +meat drop
* [vampyre] Use Bats form at Alcove
* [vampyre] Use Eye of the Giger
* Stop aborting on mispredicted zeppelin


Fixes #106 and #114.