### PR TITLE
Switch horses when tweaking combat mods

### DIFF
--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -212,7 +212,7 @@ void handlePreAdventure(location place)
 	}
 
 	bat_formPreAdventure();
-        horsePreAdventure();
+	horsePreAdventure();
 
 	generic_t itemNeed = zone_needItem(place);
 	if(itemNeed._boolean && (item_drop_modifier() < itemNeed._float))

--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -212,6 +212,7 @@ void handlePreAdventure(location place)
 	}
 
 	bat_formPreAdventure();
+        horsePreAdventure();
 
 	generic_t itemNeed = zone_needItem(place);
 	if(itemNeed._boolean && (item_drop_modifier() < itemNeed._float))

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -10370,7 +10370,7 @@ boolean LX_craftAcquireItems()
 
 	if(sl_my_path() != "Community Service")
 	{
-		getHorse("noncombat");
+		horseDark();
 		if(item_amount($item[Portable Pantogram]) > 0)
 		{
 			switch(my_daycount())

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -7450,6 +7450,13 @@ boolean L12_sonofaBeach()
 			}
 		}
 		asdonBuff($effect[Driving Obnoxiously]);
+                if (get_property("_horsery") == "dark horse")
+                {
+                        horseNone();
+                        getHorse("return");
+                        // note: it's retrieving the dark horse before every adventure
+                }
+
 		if(numeric_modifier("Combat Rate") < 0.0)
 		{
 			print("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -7450,12 +7450,6 @@ boolean L12_sonofaBeach()
 			}
 		}
 		asdonBuff($effect[Driving Obnoxiously]);
-                if (get_property("_horsery") == "dark horse")
-                {
-                        horseNone();
-                        getHorse("return");
-                        // note: it's retrieving the dark horse before every adventure
-                }
 
 		if(numeric_modifier("Combat Rate") < 0.0)
 		{

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -10371,7 +10371,6 @@ boolean LX_craftAcquireItems()
 
 	if(sl_my_path() != "Community Service")
 	{
-		horseDark();
 		if(item_amount($item[Portable Pantogram]) > 0)
 		{
 			switch(my_daycount())
@@ -14070,6 +14069,7 @@ boolean doTasks()
 		cli_execute("refresh inv");
 	}
 	bat_formNone();
+        horseDefault();
 
 	basicAdjustML();
 	powerLevelAdjustment();

--- a/RELEASE/scripts/sl_ascend/sl_aftercore.ash
+++ b/RELEASE/scripts/sl_ascend/sl_aftercore.ash
@@ -914,7 +914,7 @@ boolean sl_cheesePostCS(int leave)
 	{
 		songboomSetting($item[Gathered Meat-Clip]);
 	}
-	getHorse("meat");
+	horseDark();
 	dailyEvents();
 
 	if(((my_daycount() == 2) && isOverdueDigitize()) || get_property("_sl_specialAftercore").to_boolean())

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -592,6 +592,12 @@ boolean sl_sausageEatEmUp(); // Defined in sl_ascend/sl_mr2019.ash
 boolean getSpaceJelly();									//Defined in sl_ascend/sl_mr2017.ash
 int horseCost();											//Defined in sl_ascend/sl_mr2017.ash
 boolean getHorse(string type);								//Defined in sl_ascend/sl_mr2017.ash
+void horseNone(); // Defined in sl_ascend/sl_mr2017.ash
+void horseNormal(); // Defined in sl_ascend/sl_mr2017.ash
+void horseDark(); // Defined in sl_ascend/sl_mr2017.ash
+void horseCrazy(); // Defined in sl_ascend/sl_mr2017.ash
+void horsePale(); // Defined in sl_ascend/sl_mr2017.ash
+boolean horsePreAdventure(); // Defined in sl_ascend/sl_mr2017.ash
 boolean kgbDiscovery();										//Defined in sl_ascend/sl_mr2017.ash
 boolean kgbWasteClicks();									//Defined in sl_ascend/sl_mr2017.ash
 boolean kgbTryEffect(effect ef);							//Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -592,6 +592,7 @@ boolean sl_sausageEatEmUp(); // Defined in sl_ascend/sl_mr2019.ash
 boolean getSpaceJelly();									//Defined in sl_ascend/sl_mr2017.ash
 int horseCost();											//Defined in sl_ascend/sl_mr2017.ash
 boolean getHorse(string type);								//Defined in sl_ascend/sl_mr2017.ash
+void horseDefault(); // Defined in sl_ascend/sl_mr2017.ash
 void horseNone(); // Defined in sl_ascend/sl_mr2017.ash
 void horseNormal(); // Defined in sl_ascend/sl_mr2017.ash
 void horseDark(); // Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -591,8 +591,10 @@ boolean sl_sausageEatEmUp(int maximumToEat); // Defined in sl_ascend/sl_mr2019.a
 boolean sl_sausageEatEmUp(); // Defined in sl_ascend/sl_mr2019.ash
 boolean getSpaceJelly();									//Defined in sl_ascend/sl_mr2017.ash
 int horseCost();											//Defined in sl_ascend/sl_mr2017.ash
+string horseNormalize(string horseText); // Defined in sl_ascend/sl_mr2017.ash
 boolean getHorse(string type);								//Defined in sl_ascend/sl_mr2017.ash
 void horseDefault(); // Defined in sl_ascend/sl_mr2017.ash
+void horseMaintain(); // Defined in sl_ascend/sl_mr2017.ash
 void horseNone(); // Defined in sl_ascend/sl_mr2017.ash
 void horseNormal(); // Defined in sl_ascend/sl_mr2017.ash
 void horseDark(); // Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -2523,7 +2523,8 @@ boolean LA_cs_communityService()
 			{
 				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
 			}
-			horseDark();
+                        // Not using the horsePreAdventure system, Community Service tasks may not pass through presool.ash
+			getHorse("non-combat");
 
 			if(my_adventures() < questCost)
 			{
@@ -2808,7 +2809,8 @@ boolean LA_cs_communityService()
 			}
 
 			asdonBuff($effect[Driving Safely]);
-			horsePale();
+                        // Not using the horsePreAdventure system, Community Service tasks may not pass through presool.ash
+			getHorse("resistance");
 
 			while((my_mp() < 37) && (get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
 			{

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -2523,7 +2523,8 @@ boolean LA_cs_communityService()
 			{
 				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
 			}
-                        // Not using the horsePreAdventure system, Community Service tasks may not pass through presool.ash
+                        horseDark();
+                        // Force horse switch in case our next action doesn't use presool.ash
 			getHorse("non-combat");
 
 			if(my_adventures() < questCost)
@@ -2809,7 +2810,8 @@ boolean LA_cs_communityService()
 			}
 
 			asdonBuff($effect[Driving Safely]);
-                        // Not using the horsePreAdventure system, Community Service tasks may not pass through presool.ash
+                        horsePale();
+                        // Force horse switch in case our next action doesn't use presool.ash
 			getHorse("resistance");
 
 			while((my_mp() < 37) && (get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
@@ -4986,16 +4988,19 @@ boolean cs_preTurnStuff(int curQuest)
 	case 1:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
-			getHorse("regen");
+                        horseNormal();
+                        getHorse("regen");
 		}
 	case 2:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
+                        horseDark();
 			getHorse("non-combat");
 		}
 	default:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
+                        horseDark();
 			getHorse("non-combat");
 		}
 	}

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -2523,7 +2523,7 @@ boolean LA_cs_communityService()
 			{
 				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
 			}
-			getHorse("non-combat");
+			horseDark();
 
 			if(my_adventures() < questCost)
 			{
@@ -2808,7 +2808,7 @@ boolean LA_cs_communityService()
 			}
 
 			asdonBuff($effect[Driving Safely]);
-			getHorse("resistance");
+			horsePale();
 
 			while((my_mp() < 37) && (get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
 			{

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -4984,7 +4984,7 @@ boolean cs_preTurnStuff(int curQuest)
 	case 1:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
-                        getHorse("regen");
+			getHorse("regen");
 		}
 	case 2:
 		if(get_property("_horseryRented").to_int() == 0)

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -2523,8 +2523,6 @@ boolean LA_cs_communityService()
 			{
 				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
 			}
-                        horseDark();
-                        // Force horse switch in case our next action doesn't use presool.ash
 			getHorse("non-combat");
 
 			if(my_adventures() < questCost)
@@ -2810,8 +2808,6 @@ boolean LA_cs_communityService()
 			}
 
 			asdonBuff($effect[Driving Safely]);
-                        horsePale();
-                        // Force horse switch in case our next action doesn't use presool.ash
 			getHorse("resistance");
 
 			while((my_mp() < 37) && (get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
@@ -4988,19 +4984,16 @@ boolean cs_preTurnStuff(int curQuest)
 	case 1:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
-                        horseNormal();
                         getHorse("regen");
 		}
 	case 2:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
-                        horseDark();
 			getHorse("non-combat");
 		}
 	default:
 		if(get_property("_horseryRented").to_int() == 0)
 		{
-                        horseDark();
 			getHorse("non-combat");
 		}
 	}

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1497,7 +1497,7 @@ boolean getHorse(string type)
 	}
 
 	int choice = -1;
-	if((type == "regen") || (type == "init") || (get_property("sl_beatenUpCount").to_int() >= 20))
+	if((horseNormalize(type) == "normal") || (get_property("sl_beatenUpCount").to_int() >= 20))
 	{
 		if(get_property("_horsery") == "normal horse")
 		{
@@ -1507,7 +1507,7 @@ boolean getHorse(string type)
 		set_property("sl_desiredHorse", "regen");
 
 	}
-	else if((type == "-combat") || (type == "noncombat") || (type == "non-combat") || (type == "meat"))
+	else if(horseNormalize(type) == "dark")
 	{
 		if(get_property("_horsery") == "dark horse")
 		{
@@ -1516,7 +1516,7 @@ boolean getHorse(string type)
 		choice = 2;
 		set_property("sl_desiredHorse", "noncombat");
 	}
-	else if((type == "random") || (type == "hookah"))
+	else if(horseNormalize(type) == "crazy")
 	{
 		if(contains_text(get_property("_horsery"), "crazy horse"))
 		{
@@ -1525,7 +1525,7 @@ boolean getHorse(string type)
 		choice = 3;
 		set_property("sl_desiredHorse", "random");
 	}
-	else if((type == "res") || (type == "resistance") || (type == "spooky") || (type == "damage"))
+	else if(horseNormalize(type) == "pale")
 	{
 		if(contains_text(get_property("_horsery"), "pale horse"))
 		{
@@ -1534,7 +1534,7 @@ boolean getHorse(string type)
 		choice = 4;
 		set_property("sl_desiredHorse", "resistance");
 	}
-	else if(type == "return")
+	else if(horseNormalize(type) == "return")
 	{
 		if(get_property("_horsery") == "")
 		{

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1485,6 +1485,10 @@ boolean getHorse(string type)
 	}
 	else if(type == "return")
 	{
+                if(get_property("_horsery") == "")
+                {
+                        return false;
+                }
 		choice = 5;
 		set_property("_horsery", "");
                 set_property("sl_desiredHorse", "return");

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1448,11 +1448,12 @@ boolean getHorse(string type)
 	int choice = -1;
 	if((type == "regen") || (type == "init") || (get_property("sl_beatenUpCount").to_int() >= 20))
 	{
-		choice = 1;
 		if(get_property("_horsery") == "normal horse")
 		{
 			return false;
 		}
+                choice = 1;
+                set_property("sl_desiredHorse", "regen");
 
 	}
 	else if((type == "-combat") || (type == "noncombat") || (type == "non-combat") || (type == "meat"))
@@ -1462,6 +1463,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 2;
+                set_property("sl_desiredHorse", "noncombat");
 	}
 	else if((type == "random") || (type == "hookah"))
 	{
@@ -1470,6 +1472,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 3;
+                set_property("sl_desiredHorse", "random");
 	}
 	else if((type == "res") || (type == "resistance") || (type == "spooky") || (type == "damage"))
 	{
@@ -1478,11 +1481,13 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 4;
+                set_property("sl_desiredHorse", "resistance");
 	}
 	else if(type == "return")
 	{
 		choice = 5;
 		set_property("_horsery", "");
+                set_property("sl_desiredHorse", "return");
 	}
 
 	if(choice == -1)

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1480,7 +1480,7 @@ string horseNormalize(string horseText)
 		return "pale";
 	}
 
-	print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+	print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
 	return "";
 }
 
@@ -1504,7 +1504,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 1;
-		set_property("sl_desiredHorse", "regen");
+		set_property("sl_desiredHorse", "normal");
 
 	}
 	else if(horseNormalize(type) == "dark")
@@ -1514,7 +1514,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 2;
-		set_property("sl_desiredHorse", "noncombat");
+		set_property("sl_desiredHorse", "dark");
 	}
 	else if(horseNormalize(type) == "crazy")
 	{
@@ -1523,7 +1523,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 3;
-		set_property("sl_desiredHorse", "random");
+		set_property("sl_desiredHorse", "crazy");
 	}
 	else if(horseNormalize(type) == "pale")
 	{
@@ -1532,7 +1532,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 4;
-		set_property("sl_desiredHorse", "resistance");
+		set_property("sl_desiredHorse", "pale");
 	}
 	else if(horseNormalize(type) == "return")
 	{
@@ -1575,22 +1575,22 @@ void horseNone()
 
 void horseNormal()
 {
-	set_property("sl_desiredHorse", "regen");
+	set_property("sl_desiredHorse", "normal");
 }
 
 void horseDark()
 {
-	set_property("sl_desiredHorse", "noncombat");
+	set_property("sl_desiredHorse", "dark");
 }
 
 void horseCrazy()
 {
-	set_property("sl_desiredHorse", "random");
+	set_property("sl_desiredHorse", "crazy");
 }
 
 void horsePale()
 {
-	set_property("sl_desiredHorse", "resistance");
+	set_property("sl_desiredHorse", "pale");
 }
 
 boolean horsePreAdventure()
@@ -1598,16 +1598,16 @@ boolean horsePreAdventure()
 	string desiredHorse = get_property("sl_desiredHorse");
 	if (desiredHorse == "")
 	{
-		desiredHorse = "noncombat";
+		desiredHorse = "dark";
 	}
 
-	if (desiredHorse != "regen"
-	    && desiredHorse != "noncombat"
-	    && desiredHorse != "random"
-	    && desiredHorse != "resistance"
+	if (desiredHorse != "normal"
+	    && desiredHorse != "dark"
+	    && desiredHorse != "crazy"
+	    && desiredHorse != "pale"
 	    && desiredHorse != "return")
 	{
-		print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+		print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
 		set_property("sl_desiredHorse", "");
 		return false;
 	}

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1437,28 +1437,33 @@ string horseNormalize(string horseText)
 {
 	switch(horseText)
 	{
-		case "normal horse":	return "normal";
-		case "normal":		return "normal";
-		case "regen":		return "normal";
-		case "init":		return "normal";
-		case "dark horse":	return "dark";
-		case "dark":		return "dark";
-		case "meat":		return "dark";
-		case "-combat":		return "dark";
-		case "noncombat":	return "dark";
-		case "non-combat":	return "dark";
-		case "crazy horse":	return "crazy";
-		case "crazy":		return "crazy";
-		case "hookah":		return "crazy";
-		case "random":		return "crazy";
-		case "pale horse":	return "pale";
-		case "pale":		return "pale";
-		case "res":		return "pale";
-		case "resistance":	return "pale";
-		case "spooky":		return "pale";
-		case "damage":		return "pale";
-		case "return":		return "return";
-		case "":		return "return";
+		case "normal horse":
+		case "normal":
+		case "regen":
+		case "init":
+			return "normal";
+		case "dark horse":
+		case "dark":
+		case "meat":
+		case "-combat":
+		case "noncombat":
+		case "non-combat":
+			return "dark";
+		case "crazy horse":
+		case "crazy":
+		case "hookah":
+		case "random":
+			return "crazy";
+		case "pale horse":
+		case "pale":
+		case "res":
+		case "resistance":
+		case "spooky":
+		case "damage":
+			return "pale";
+		case "return":
+		case "":
+			return "return";
 	}
 
 	if (contains_text(horseText, "normal horse"))

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1437,24 +1437,28 @@ string horseNormalize(string horseText)
 {
 	switch(horseText)
 	{
-		case "normal":	   return "normal";
-		case "regen":	   return "normal";
-		case "init":	   return "normal";
-		case "dark":	   return "dark";
-		case "meat":	   return "dark";
-		case "-combat":	   return "dark";
-		case "noncombat":  return "dark";
-		case "non-combat": return "dark";
-		case "crazy":	   return "crazy";
-		case "hookah":	   return "crazy";
-		case "random":	   return "crazy";
-		case "pale":	   return "pale";
-		case "res":	   return "pale";
-		case "resistance": return "pale";
-		case "spooky":	   return "pale";
-		case "damage":	   return "pale";
-		case "return":	   return "return";
-		case "":	   return "return";
+		case "normal horse":	return "normal";
+		case "normal":		return "normal";
+		case "regen":		return "normal";
+		case "init":		return "normal";
+		case "dark horse":	return "dark";
+		case "dark":		return "dark";
+		case "meat":		return "dark";
+		case "-combat":		return "dark";
+		case "noncombat":	return "dark";
+		case "non-combat":	return "dark";
+		case "crazy horse":	return "crazy";
+		case "crazy":		return "crazy";
+		case "hookah":		return "crazy";
+		case "random":		return "crazy";
+		case "pale horse":	return "pale";
+		case "pale":		return "pale";
+		case "res":		return "pale";
+		case "resistance":	return "pale";
+		case "spooky":		return "pale";
+		case "damage":		return "pale";
+		case "return":		return "return";
+		case "":		return "return";
 	}
 
 	if (contains_text(horseText, "normal horse"))

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1503,6 +1503,10 @@ boolean getHorse(string type)
 	return true;
 }
 
+void horseDefault()
+{
+        set_property("sl_desiredHorse", "");
+}
 void horseNone()
 {
         set_property("sl_desiredHorse", "return");
@@ -1531,6 +1535,11 @@ void horsePale()
 boolean horsePreAdventure()
 {
         string desiredHorse = get_property("sl_desiredHorse");
+        if (desiredHorse == "")
+        {
+                desiredHorse = "noncombat";
+        }
+
         if (desiredHorse != "regen"
             && desiredHorse != "noncombat"
             && desiredHorse != "random"

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1435,44 +1435,44 @@ int horseCost()
 
 string horseNormalize(string horseText)
 {
-        switch(horseText)
+	switch(horseText)
 	{
-                case "normal":     return "normal";
-	        case "regen":      return "normal";
-	        case "init":       return "normal";
-                case "dark":       return "dark";
-                case "meat":       return "dark";
-	        case "-combat":    return "dark";
-	        case "noncombat":  return "dark";
-                case "non-combat": return "dark";
-                case "crazy":      return "crazy";
-                case "hookah":     return "crazy";
-                case "random":     return "crazy";
-                case "pale":       return "pale";
-                case "res":        return "pale";
-                case "resistance": return "pale";
-                case "spooky":     return "pale";
-                case "damage":     return "pale";
-                case "return":     return "return";
-                case "":           return "return";
+		case "normal":	   return "normal";
+		case "regen":	   return "normal";
+		case "init":	   return "normal";
+		case "dark":	   return "dark";
+		case "meat":	   return "dark";
+		case "-combat":	   return "dark";
+		case "noncombat":  return "dark";
+		case "non-combat": return "dark";
+		case "crazy":	   return "crazy";
+		case "hookah":	   return "crazy";
+		case "random":	   return "crazy";
+		case "pale":	   return "pale";
+		case "res":	   return "pale";
+		case "resistance": return "pale";
+		case "spooky":	   return "pale";
+		case "damage":	   return "pale";
+		case "return":	   return "return";
+		case "":	   return "return";
 	}
 
-        if (contains_text(horseText, "normal horse"))
-        {
-                return "normal";
-        } else if (contains_text(horseText, "dark horse"))
-        {
-                return "dark";
-        } else if (contains_text(horseText, "crazy horse"))
-        {
-                return "crazy";
-        } else if (contains_text(horseText, "pale horse"))
-        {
-                return "pale";
-        }
+	if (contains_text(horseText, "normal horse"))
+	{
+		return "normal";
+	} else if (contains_text(horseText, "dark horse"))
+	{
+		return "dark";
+	} else if (contains_text(horseText, "crazy horse"))
+	{
+		return "crazy";
+	} else if (contains_text(horseText, "pale horse"))
+	{
+		return "pale";
+	}
 
-        print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
-        return "";
+	print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+	return "";
 }
 
 boolean getHorse(string type)
@@ -1494,8 +1494,8 @@ boolean getHorse(string type)
 		{
 			return false;
 		}
-                choice = 1;
-                set_property("sl_desiredHorse", "regen");
+		choice = 1;
+		set_property("sl_desiredHorse", "regen");
 
 	}
 	else if((type == "-combat") || (type == "noncombat") || (type == "non-combat") || (type == "meat"))
@@ -1505,7 +1505,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 2;
-                set_property("sl_desiredHorse", "noncombat");
+		set_property("sl_desiredHorse", "noncombat");
 	}
 	else if((type == "random") || (type == "hookah"))
 	{
@@ -1514,7 +1514,7 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 3;
-                set_property("sl_desiredHorse", "random");
+		set_property("sl_desiredHorse", "random");
 	}
 	else if((type == "res") || (type == "resistance") || (type == "spooky") || (type == "damage"))
 	{
@@ -1523,17 +1523,17 @@ boolean getHorse(string type)
 			return false;
 		}
 		choice = 4;
-                set_property("sl_desiredHorse", "resistance");
+		set_property("sl_desiredHorse", "resistance");
 	}
 	else if(type == "return")
 	{
-                if(get_property("_horsery") == "")
-                {
-                        return false;
-                }
+		if(get_property("_horsery") == "")
+		{
+			return false;
+		}
 		choice = 5;
 		set_property("_horsery", "");
-                set_property("sl_desiredHorse", "return");
+		set_property("sl_desiredHorse", "return");
 	}
 
 	if(choice == -1)
@@ -1551,58 +1551,58 @@ boolean getHorse(string type)
 
 void horseDefault()
 {
-        set_property("sl_desiredHorse", "");
+	set_property("sl_desiredHorse", "");
 }
 
 void horseMaintain()
 {
-        set_property("sl_desiredHorse", horseNormalize(get_property("_horsery")));
+	set_property("sl_desiredHorse", horseNormalize(get_property("_horsery")));
 }
 
 void horseNone()
 {
-        set_property("sl_desiredHorse", "return");
+	set_property("sl_desiredHorse", "return");
 }
 
 void horseNormal()
 {
-        set_property("sl_desiredHorse", "regen");
+	set_property("sl_desiredHorse", "regen");
 }
 
 void horseDark()
 {
-        set_property("sl_desiredHorse", "noncombat");
+	set_property("sl_desiredHorse", "noncombat");
 }
 
 void horseCrazy()
 {
-        set_property("sl_desiredHorse", "random");
+	set_property("sl_desiredHorse", "random");
 }
 
 void horsePale()
 {
-        set_property("sl_desiredHorse", "resistance");
+	set_property("sl_desiredHorse", "resistance");
 }
 
 boolean horsePreAdventure()
 {
-        string desiredHorse = get_property("sl_desiredHorse");
-        if (desiredHorse == "")
-        {
-                desiredHorse = "noncombat";
-        }
+	string desiredHorse = get_property("sl_desiredHorse");
+	if (desiredHorse == "")
+	{
+		desiredHorse = "noncombat";
+	}
 
-        if (desiredHorse != "regen"
-            && desiredHorse != "noncombat"
-            && desiredHorse != "random"
-            && desiredHorse != "resistance"
-            && desiredHorse != "return")
-        {
-                print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+	if (desiredHorse != "regen"
+	    && desiredHorse != "noncombat"
+	    && desiredHorse != "random"
+	    && desiredHorse != "resistance"
+	    && desiredHorse != "return")
+	{
+		print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
 		set_property("sl_desiredHorse", "");
 		return false;
-        }
-        return getHorse(desiredHorse);
+	}
+	return getHorse(desiredHorse);
 }
 
 boolean makeGenieWish(effect eff)

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1433,6 +1433,48 @@ int horseCost()
 	return 0;
 }
 
+string horseNormalize(string horseText)
+{
+        switch(horseText)
+	{
+                case "normal":     return "normal";
+	        case "regen":      return "normal";
+	        case "init":       return "normal";
+                case "dark":       return "dark";
+                case "meat":       return "dark";
+	        case "-combat":    return "dark";
+	        case "noncombat":  return "dark";
+                case "non-combat": return "dark";
+                case "crazy":      return "crazy";
+                case "hookah":     return "crazy";
+                case "random":     return "crazy";
+                case "pale":       return "pale";
+                case "res":        return "pale";
+                case "resistance": return "pale";
+                case "spooky":     return "pale";
+                case "damage":     return "pale";
+                case "return":     return "return";
+                case "":           return "return";
+	}
+
+        if (contains_text(horseText, "normal horse"))
+        {
+                return "normal";
+        } else if (contains_text(horseText, "dark horse"))
+        {
+                return "dark";
+        } else if (contains_text(horseText, "crazy horse"))
+        {
+                return "crazy";
+        } else if (contains_text(horseText, "pale horse"))
+        {
+                return "pale";
+        }
+
+        print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+        return "";
+}
+
 boolean getHorse(string type)
 {
 	if(!get_property("horseryAvailable").to_boolean())
@@ -1511,6 +1553,12 @@ void horseDefault()
 {
         set_property("sl_desiredHorse", "");
 }
+
+void horseMaintain()
+{
+        set_property("sl_desiredHorse", horseNormalize(get_property("_horsery")));
+}
+
 void horseNone()
 {
         set_property("sl_desiredHorse", "return");

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1500,10 +1500,7 @@ boolean getHorse(string type)
 
 void horseNone()
 {
-        if(get_property("sl_desiredHorse") != "")
-	{
-		set_property("sl_desiredHorse", "");
-	}
+        set_property("sl_desiredHorse", "return");
 }
 
 void horseNormal()
@@ -1532,7 +1529,8 @@ boolean horsePreAdventure()
         if (desiredHorse != "regen"
             && desiredHorse != "noncombat"
             && desiredHorse != "random"
-            && desiredHorse != "resistance")
+            && desiredHorse != "resistance"
+            && desiredHorse != "return")
         {
                 print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
 		set_property("sl_desiredHorse", "");

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1529,7 +1529,7 @@ void horsePale()
 boolean horsePreAdventure()
 {
         string desiredHorse = get_property("sl_desiredHorse");
-        if (desiredHose != "regen"
+        if (desiredHorse != "regen"
             && desiredHorse != "noncombat"
             && desiredHorse != "random"
             && desiredHorse != "resistance")

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1498,6 +1498,49 @@ boolean getHorse(string type)
 	return true;
 }
 
+void horseNone()
+{
+        if(get_property("sl_desiredHorse") != "")
+	{
+		set_property("sl_desiredHorse", "");
+	}
+}
+
+void horseNormal()
+{
+        set_property("sl_desiredHorse", "regen");
+}
+
+void horseDark()
+{
+        set_property("sl_desiredHorse", "noncombat");
+}
+
+void horseCrazy()
+{
+        set_property("sl_desiredHorse", "random");
+}
+
+void horsePale()
+{
+        set_property("sl_desiredHorse", "resistance");
+}
+
+boolean horsePreAdventure()
+{
+        string desiredHorse = get_property("sl_desiredHorse");
+        if (desiredHose != "regen"
+            && desiredHorse != "noncombat"
+            && desiredHorse != "random"
+            && desiredHorse != "resistance")
+        {
+                print("sl_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'regen', 'noncombat', 'random', or 'resistance'.", "red");
+		set_property("sl_desiredHorse", "");
+		return false;
+        }
+        return getHorse(desiredHorse);
+}
+
 boolean makeGenieWish(effect eff)
 {
 	if(item_amount($item[Genie Bottle]) == 0)

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2744,7 +2744,7 @@ boolean providePlusCombat(int amt, boolean doEquips)
         if((numeric_modifier("Combat Rate").to_int() < amt)
            && (get_property("_horsery") == "dark horse"))
         {
-                getHorse("return");
+                horseNone();
         }
 
 	if(numeric_modifier("Combat Rate").to_int() < amt)
@@ -2814,7 +2814,7 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 
         if((numeric_modifier("Combat Rate").to_int() > amt))
         {
-                getHorse("noncombat");
+                horseDark();
         }
 
 	if(numeric_modifier("Combat Rate").to_int() > amt)

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2741,6 +2741,14 @@ boolean providePlusCombat(int amt, boolean doEquips)
 		}
 	}
 
+        if((numeric_modifier("Combat Rate").to_int() < amt)
+           && get_property("horseryAvailable").to_boolean()
+           && (get_property("_horsery") == "dark horse")
+           && (my_meat() >= 1000))
+        {
+                cli_execute("horsery normal");
+        }
+
 	if(numeric_modifier("Combat Rate").to_int() < amt)
 	{
 		asdonBuff($effect[Driving Obnoxiously]);
@@ -2805,6 +2813,14 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		}
 		removeCombat();
 	}
+
+        if((numeric_modifier("Combat Rate").to_int() > amt)
+           && get_property("horseryAvailable").to_boolean()
+           && (get_property("_horsery") != "dark horse")
+           && (my_meat() >= 1000))
+        {
+                cli_execute("horsery dark");
+        }
 
 	if(numeric_modifier("Combat Rate").to_int() > amt)
 	{

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2744,7 +2744,7 @@ boolean providePlusCombat(int amt, boolean doEquips)
         if((numeric_modifier("Combat Rate").to_int() < amt)
            && (get_property("_horsery") == "dark horse"))
         {
-                horseNone();
+                getHorse("return");
         }
 
 	if(numeric_modifier("Combat Rate").to_int() < amt)
@@ -2814,7 +2814,7 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 
         if((numeric_modifier("Combat Rate").to_int() > amt))
         {
-                horseDark();
+                getHorse("noncombat");
         }
 
 	if(numeric_modifier("Combat Rate").to_int() > amt)

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2741,15 +2741,15 @@ boolean providePlusCombat(int amt, boolean doEquips)
 		}
 	}
 
-        if((numeric_modifier("Combat Rate").to_int() < amt)
-           && (get_property("_horsery") == "dark horse"))
-        {
-                getHorse("return");
-        }
-        else
-        {
-                horseMaintain();
-        }
+	if((numeric_modifier("Combat Rate").to_int() < amt)
+	   && (get_property("_horsery") == "dark horse"))
+	{
+		getHorse("return");
+	}
+	else
+	{
+		horseMaintain();
+	}
 
 	if(numeric_modifier("Combat Rate").to_int() < amt)
 	{
@@ -2816,10 +2816,10 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		removeCombat();
 	}
 
-        if((numeric_modifier("Combat Rate").to_int() > amt))
-        {
-                getHorse("noncombat");
-        }
+	if((numeric_modifier("Combat Rate").to_int() > amt))
+	{
+		getHorse("noncombat");
+	}
 
 	if(numeric_modifier("Combat Rate").to_int() > amt)
 	{

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2746,6 +2746,10 @@ boolean providePlusCombat(int amt, boolean doEquips)
         {
                 getHorse("return");
         }
+        else
+        {
+                horseMaintain();
+        }
 
 	if(numeric_modifier("Combat Rate").to_int() < amt)
 	{

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2742,11 +2742,9 @@ boolean providePlusCombat(int amt, boolean doEquips)
 	}
 
         if((numeric_modifier("Combat Rate").to_int() < amt)
-           && get_property("horseryAvailable").to_boolean()
-           && (get_property("_horsery") == "dark horse")
-           && (my_meat() >= 1000))
+           && (get_property("_horsery") == "dark horse"))
         {
-                cli_execute("horsery normal");
+                getHorse("return");
         }
 
 	if(numeric_modifier("Combat Rate").to_int() < amt)
@@ -2814,12 +2812,9 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		removeCombat();
 	}
 
-        if((numeric_modifier("Combat Rate").to_int() > amt)
-           && get_property("horseryAvailable").to_boolean()
-           && (get_property("_horsery") != "dark horse")
-           && (my_meat() >= 1000))
+        if((numeric_modifier("Combat Rate").to_int() > amt))
         {
-                cli_execute("horsery dark");
+                getHorse("noncombat");
         }
 
 	if(numeric_modifier("Combat Rate").to_int() > amt)


### PR DESCRIPTION
## Description of changes

`sl_ascend`  grabs the Dark Horse before each adventure for its -combat modifier. Upon reaching the war in HC DG, I found it wouldn't do the Lighthouse quest because it couldn't get enough +combat to override the Dark Horse. It would just say:

`Something is keeping us from getting a suitable combat rate, we have: -5.0 and Lobsterfrogmen.`

While KoLMafia's maximizer does know about Horsery, my understanding is that we don't want to call into it regularly. So, I've added manual checks for Horsery settings in the combat modifier functions.

Similar to the Asdon, it costs meat to switch, so I put it towards the bottom of the list. I put it before the Asdon check, assuming Asdon costs more than 500 to switch. At any rate, we want the cheapest one to be first, so I'll switch if needed.

With these changes, `sl_ascend` did the Lighthouse quest, so I'm happy :)

## Stuff to maybe look at fixing

1. Check if Horsery is unrestricted. I've seen the `$item` syntax for checking this, but Horsery is a location, so I'm not sure how to check that. Right now we're using `_horseryAvailable`, and I don't know if that checks for restrictions on usage