### PR TITLE
Genie usage, fix Fortune Teller usage

### DIFF
--- a/BUILD/equipment/acc.dat
+++ b/BUILD/equipment/acc.dat
@@ -38,6 +38,7 @@ Time-Twitching Toolbelt
 Mr. Accessory Jr.
 Iron Beta of Industry
 LOV Earrings
+wax hand
 Perfume-Soaked Bandana
 Wicker Kickers
 Compression Stocking

--- a/BUILD/equipment/back.dat
+++ b/BUILD/equipment/back.dat
@@ -8,6 +8,7 @@ Buddy Bjorn
 Vampyric Cloake
 Polyester Parachute
 Makeshift Cape
+Sea Shawl
 Misty Robe
 Misty Cape
 Misty Cloak

--- a/BUILD/equipment/hat.dat
+++ b/BUILD/equipment/hat.dat
@@ -31,6 +31,7 @@ Van der Graaf helmet
 Astral Chapeau
 Wad Of Used Tape
 Meteortarboard
+chalk chapeau
 Psychic's Circlet
 seven-gallon hat
 six-gallon hat

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -47,5 +47,6 @@ sl_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (a
 sl_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 sl_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
 sl_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+sl_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
 sl_beta_test	boolean	Occasionally I might need to make big changes, but not want to do so without some broader testing. If you're a kind, generous soul, you can test these features by setting this to true! sl_beta_test will be mentioned in the change logs whenever there is something to test, and mentioned again when that feature stops being a beta feature.
 sl_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -81,18 +81,19 @@ back	5	Buddy Bjorn
 back	6	Vampyric Cloake
 back	7	Polyester Parachute
 back	8	Makeshift Cape
-back	9	Misty Robe
-back	10	Misty Cape
-back	11	Misty Cloak
-back	12	Frozen Turtle Shell
-back	13	Giant Gym Membership Card
-back	14	Fiberglass Frock
-back	15	Gabardine Gunnysack
-back	16	Oil Shell
-back	17	Pillow Shell
-back	18	Black Cloak
-back	19	Whatsit-Covered Turtle Shell
-back	20	Barskin Cloak
+back	9	Sea Shawl
+back	10	Misty Robe
+back	11	Misty Cape
+back	12	Misty Cloak
+back	13	Frozen Turtle Shell
+back	14	Giant Gym Membership Card
+back	15	Fiberglass Frock
+back	16	Gabardine Gunnysack
+back	17	Oil Shell
+back	18	Pillow Shell
+back	19	Black Cloak
+back	20	Whatsit-Covered Turtle Shell
+back	21	Barskin Cloak
 
 # Familiar gear
 familiar	0	miniature life preserver	path:Heavy Rains

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -51,25 +51,26 @@ acc	35	Time-Twitching Toolbelt
 acc	36	Mr. Accessory Jr.
 acc	37	Iron Beta of Industry
 acc	38	LOV Earrings
-acc	39	Perfume-Soaked Bandana
-acc	40	Wicker Kickers
-acc	41	Compression Stocking
-acc	42	Glow-In-The-Dark Necklace
-acc	43	Pirate Fledges
-acc	44	Plastic Detective Badge
-acc	45	Jangly Bracelet
-acc	46	Jolly Roger Charrrm Bracelet
-acc	47	Grumpy Old Man Charrrm Bracelet
-acc	48	Bonerdagon Necklace
-acc	49	Batskin Belt
-acc	50	Garish Pinky Ring
-acc	51	Ring Of Telling Skeletons What To Do
-acc	52	Imp Unity Ring
-acc	53	Infernal Insoles
-acc	54	Glowing Red Eye
-acc	55	Stuffed Shoulder Parrot
-acc	56	Vampire Collar
-acc	57	Jaunty Feather
+acc	39	wax hand
+acc	40	Perfume-Soaked Bandana
+acc	41	Wicker Kickers
+acc	42	Compression Stocking
+acc	43	Glow-In-The-Dark Necklace
+acc	44	Pirate Fledges
+acc	45	Plastic Detective Badge
+acc	46	Jangly Bracelet
+acc	47	Jolly Roger Charrrm Bracelet
+acc	48	Grumpy Old Man Charrrm Bracelet
+acc	49	Bonerdagon Necklace
+acc	50	Batskin Belt
+acc	51	Garish Pinky Ring
+acc	52	Ring Of Telling Skeletons What To Do
+acc	53	Imp Unity Ring
+acc	54	Infernal Insoles
+acc	55	Glowing Red Eye
+acc	56	Stuffed Shoulder Parrot
+acc	57	Vampire Collar
+acc	58	Jaunty Feather
 
 # Back items
 back	0	Protonic Accelerator Pack	expectghostreport:true
@@ -168,37 +169,38 @@ hat	28	Van der Graaf helmet
 hat	29	Astral Chapeau
 hat	30	Wad Of Used Tape
 hat	31	Meteortarboard
-hat	32	Psychic's Circlet
-hat	33	seven-gallon hat
-hat	34	six-gallon hat
-hat	35	five-gallon hat
-hat	36	four-gallon hat
-hat	37	three-gallon hat
-hat	38	two-gallon hat
-hat	39	one-gallon hat
-hat	40	Gravy Boat
-hat	41	Crown of the Goblin King
-hat	42	Bellhop's Hat
-hat	43	Genie's Turbane
-hat	44	Chef's Hat
-hat	45	Filthy Knitted Dread Sack
-hat	46	Football Helmet
-hat	47	Wooden Salad Bowl
-hat	48	Yellow Plastic Hard Hat
-hat	49	Dolphin King's Crown
-hat	50	Goofily-Plumed Helmet
-hat	51	Oversized Skullcap
-hat	52	Pentacorn Hat
-hat	53	Eyepatch
-hat	54	Viking Helmet
-hat	55	Knobby Helmet Turtle
-hat	56	Kentucky-Style Derby
-hat	57	Hollandaise Helmet
-hat	58	Ravioli Hat
-hat	59	Helmet Turtle
-hat	60	Seal-Skull Helmet
-hat	61	Snorkel
-hat	62	Knob Goblin Harem Veil
+hat	32	chalk chapeau
+hat	33	Psychic's Circlet
+hat	34	seven-gallon hat
+hat	35	six-gallon hat
+hat	36	five-gallon hat
+hat	37	four-gallon hat
+hat	38	three-gallon hat
+hat	39	two-gallon hat
+hat	40	one-gallon hat
+hat	41	Gravy Boat
+hat	42	Crown of the Goblin King
+hat	43	Bellhop's Hat
+hat	44	Genie's Turbane
+hat	45	Chef's Hat
+hat	46	Filthy Knitted Dread Sack
+hat	47	Football Helmet
+hat	48	Wooden Salad Bowl
+hat	49	Yellow Plastic Hard Hat
+hat	50	Dolphin King's Crown
+hat	51	Goofily-Plumed Helmet
+hat	52	Oversized Skullcap
+hat	53	Pentacorn Hat
+hat	54	Eyepatch
+hat	55	Viking Helmet
+hat	56	Knobby Helmet Turtle
+hat	57	Kentucky-Style Derby
+hat	58	Hollandaise Helmet
+hat	59	Ravioli Hat
+hat	60	Helmet Turtle
+hat	61	Seal-Skull Helmet
+hat	62	Snorkel
+hat	63	Knob Goblin Harem Veil
 
 holster	0	Pecos Dave's sixgun
 holster	1	porquoise-handled sixgun

--- a/RELEASE/data/sl_ascend_settings.txt
+++ b/RELEASE/data/sl_ascend_settings.txt
@@ -54,8 +54,9 @@ any	45	sl_slowSteelOrgan	boolean	When true, don't immediately go for the Steel O
 any	46	sl_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 any	47	sl_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
 any	48	sl_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	49	sl_beta_test	boolean	Occasionally I might need to make big changes, but not want to do so without some broader testing. If you're a kind, generous soul, you can test these features by setting this to true! sl_beta_test will be mentioned in the change logs whenever there is something to test, and mentioned again when that feature stops being a beta feature.
-any	50	sl_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	49	sl_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	50	sl_beta_test	boolean	Occasionally I might need to make big changes, but not want to do so without some broader testing. If you're a kind, generous soul, you can test these features by setting this to true! sl_beta_test will be mentioned in the change logs whenever there is something to test, and mentioned again when that feature stops being a beta feature.
+any	51	sl_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
 
 post	0	sl_getBeehive	boolean	Go for the beehive?
 post	1	sl_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -14501,7 +14501,7 @@ void sl_begin()
 	{
 		jello_startAscension(page);
 	}
-	else if(contains_text(page, "it appears that a stray bat has accidentally flown right through you"))
+	else if(contains_text(page, "it appears that a stray bat has accidentally flown right through you") || (get_property("lastAdventure") == "Intro: View of a Vampire"))
 	{
 		bat_startAscension();
 	}

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12760,9 +12760,10 @@ boolean L11_redZeppelin()
 
 	if(cloversAvailable() > 0)
 	{
-		if (get_property("sl_useWishes").to_boolean())
+		if(cloversAvailable() >= 3 && get_property("sl_useWishes").to_boolean())
 		{
-			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]);
+			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
+			makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
 		}
 		float fire_protestors = item_amount($item[Flamin' Whatshisname]) > 0 ? 10 : 3;
 		float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -6103,6 +6103,22 @@ boolean L11_unlockHiddenCity()
 	{
 		if((item_amount($item[Stone Wool]) == 0) && (have_effect($effect[Stone-Faced]) == 0))
 		{
+			if (canGenieCombat())
+			{
+				print("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
+				handleFamiliar("item");
+				if((numeric_modifier("item drop") >= 100))
+				{
+					if (!makeGenieCombat($monster[Baa'baa'bu'ran]) || item_amount($item[Stone Wool]) < 0)
+					{
+						print("Wishing for stone wool failed.", "red");
+					}
+				}
+				else
+				{
+					print("Never mind, we couldn't get a mere +100% item.", "red");
+				}
+			}
 			pullXWhenHaveY($item[Stone Wool], 1, 0);
 		}
 		buffMaintain($effect[Stone-Faced], 0, 1, 1);
@@ -9169,7 +9185,7 @@ boolean L7_crypt()
 
 		bat_formBats();
 		januaryToteAcquire($item[Broken Champagne Bottle]);
-		if((numeric_modifier("item") < 400) && (item_amount($item[Broken Champagne Bottle]) > 0) && (get_property("cyrptNookEvilness").to_int() > 26))
+		if((numeric_modifier("item drop") < 400) && (item_amount($item[Broken Champagne Bottle]) > 0) && (get_property("cyrptNookEvilness").to_int() > 26))
 		{
 			equip($item[Broken Champagne Bottle]);
 		}

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -2374,6 +2374,10 @@ boolean doBedtime()
 			makeGeniePocket();
 		}
 	}
+	if(canGenieCombat() && item_amount($item[beer helmet]) == 0)
+	{
+		print("Please consider genie wishing for an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
+	}
 
 	if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
 	{

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12727,44 +12727,76 @@ boolean L11_redZeppelin()
 		}
 	}
 
-	if($location[A Mob of Zeppelin Protesters].turns_spent % 7 == 6)
+	if(item_amount($item[Flamin\' Whatshisname]) > 0)
 	{
-		print("Oooh, the guaranteed Zeppelin noncombat is coming.", "blue");
-		// We can stock up on +sleaze damage and +sleaze spell dmg, since
-		// we know we won't get in a combat.
+		backupSetting("choiceAdventure866", 3);
+	}
+	else
+	{
+		backupSetting("choiceAdventure866", 2);
+	}
 
-		if(item_amount($item[Flamin\' Whatshisname]) > 0)
+	ccMaximize("sleaze dmg, sleaze spell dmg", 2500, 0, false);
+	foreach it in $items[lynyrdskin breeches, lynyrdskin cap, lynyrdskin tunic]
+	{
+		if(possessEquipment(it) && !have_equipped(it) && can_equip(it) &&
+		   (item_amount(it) > 0) &&
+		   (numeric_modifier(equipped_item(to_slot(it)), "sleaze dmg") < 5) &&
+		   (numeric_modifier(equipped_item(to_slot(it)), "sleaze spell dmg") < 5))
 		{
-			backupSetting("choiceAdventure866", 3);
+			equip(it);
 		}
-		else
-		{
-			backupSetting("choiceAdventure866", 2);
-		}
-
-		ccMaximize("sleaze dmg, sleaze spell dmg", 2500, 0, false);
-		foreach it in $items[lynyrdskin breeches, lynyrdskin cap, lynyrdskin tunic]
-		{
-			if(possessEquipment(it) && !have_equipped(it) && can_equip(it) &&
-			   (item_amount(it) > 0) &&
-			   (numeric_modifier(equipped_item(to_slot(it)), "sleaze dmg") < 5) &&
-			   (numeric_modifier(equipped_item(to_slot(it)), "sleaze spell dmg") < 5))
-			{
-				equip(it);
-			}
-		}
-
-		boolean retval = ccAdv($location[A Mob Of Zeppelin Protesters]);
-		if(!($strings[Bench Warrant, Fire Up Above, This Looks Like a Good Bush for an Ambush, Not So Much With The Humanity] contains get_property("lastEncounter")))
-		{
-			print("Uh oh, we expected to get a scheduled Zeppelin noncombat there but didn't. This is still being spaded - send Jeparo logs if you're interested in getting this fixed", "red");
-		}
-		return retval;
 	}
 
 	if(item_amount($item[lynyrd snare]) > 0 && get_property("_lynyrdSnareUses").to_int() < 3 && my_hp() > 150)
 	{
 		return ccAdvBypass("inv_use.php?pwd=&whichitem=7204&checked=1", $location[A Mob of Zeppelin Protesters]);
+	}
+
+	if(cloversAvailable() > 0)
+	{
+		makeGenieWish($effect[Fifty Ways to Bereave Your Lover]);
+		float fire_protestors = item_amount($item[Flamin' Whatshisname]) > 0 ? 10 : 3;
+		float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");
+		float sleaze_protestors = square_root(sleaze_amount);
+		float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
+		foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
+		{
+			if((item_amount(it) > 0) && can_equip(it))
+			{
+				lynyrd_protestors += 5;
+			}
+		}
+		print("Hiding in the bushes: " + lynyrd_protestors, "blue");
+		print("Going to a bench: " + sleaze_protestors, "blue");
+		print("Heading towards the flames" + fire_protestors, "blue");
+		float best_protestors = max(fire_protestors, max(sleaze_protestors, lynyrd_protestors));
+		if(best_protestors >= 10)
+		{
+			if(best_protestors == lynyrd_protestors)
+			{
+				foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
+				{
+					if((item_amount(it) > 0) && can_equip(it) && !have_equipped(it))
+					{
+						equip(it);
+					}
+				}
+				set_property("choiceAdventure866", 1);
+			}
+			else if(best_protestors == sleaze_protestors)
+			{
+				set_property("choiceAdventure866", 2);
+			}
+			else if (best_protestors == fire_protestors)
+			{
+				set_property("choiceAdventure866", 3);
+			}
+			cloverUsageInit();
+			boolean retval = ccAdv(1, $location[A Mob of Zeppelin Protesters]);
+			cloverUsageFinish();
+			return retval;
+		}
 	}
 
 	int lastProtest = get_property("zeppelinProtestors").to_int();

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1205,6 +1205,11 @@ boolean doThemtharHills()
 	}
 	int expectedMeat = numeric_modifier("Generated:_spec", "meat drop");
 
+
+	if(get_property("sl_useWishes").to_boolean())
+	{
+		makeGenieWish($effect[Frosty]);
+	}
 	buffMaintain($effect[Greedy Resolve], 0, 1, 1);
 	buffMaintain($effect[Disco Leer], 10, 1, 1);
 	buffMaintain($effect[Polka of Plenty], 8, 1, 1);
@@ -4897,7 +4902,7 @@ boolean L13_towerNSContests()
 
 			score = numeric_modifier(challenge + " damage ");
 			score += numeric_modifier(challenge + " spell damage ");
-			if((score < 80) && (item_amount($item[Genie bottle]) > 0))
+			if((score < 80) && get_property("sl_useWishes").to_boolean())
 			{
 				switch(challenge)
 				{
@@ -6103,7 +6108,7 @@ boolean L11_unlockHiddenCity()
 	{
 		if((item_amount($item[Stone Wool]) == 0) && (have_effect($effect[Stone-Faced]) == 0))
 		{
-			if (canGenieCombat())
+			if (get_property("sl_useWishes").to_boolean() && canGenieCombat())
 			{
 				print("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
 				handleFamiliar("item");
@@ -12755,7 +12760,10 @@ boolean L11_redZeppelin()
 
 	if(cloversAvailable() > 0)
 	{
-		makeGenieWish($effect[Fifty Ways to Bereave Your Lover]);
+		if (get_property("sl_useWishes").to_boolean())
+		{
+			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]);
+		}
 		float fire_protestors = item_amount($item[Flamin' Whatshisname]) > 0 ? 10 : 3;
 		float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");
 		float sleaze_protestors = square_root(sleaze_amount);

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -612,6 +612,7 @@ boolean asdonFeed(item it);									//Defined in sl_ascend/sl_mr2017.ash
 boolean asdonAutoFeed();									//Defined in sl_ascend/sl_mr2017.ash
 boolean asdonAutoFeed(int goal);							//Defined in sl_ascend/sl_mr2017.ash
 boolean makeGenieWish(effect eff);							//Defined in sl_ascend/sl_mr2017.ash
+boolean canGenieCombat();									//Defined in sl_ascend/sl_mr2017.ash
 boolean makeGenieCombat(monster mon, string option);		//Defined in sl_ascend/sl_mr2017.ash
 boolean makeGenieCombat(monster mon);						//Defined in sl_ascend/sl_mr2017.ash
 boolean makeGeniePocket();									//Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_clan.ash
+++ b/RELEASE/scripts/sl_ascend/sl_clan.ash
@@ -440,9 +440,10 @@ boolean zataraClanmate(string who)
 	}
 	else
 	{
+		clanName = "Bonus Adventures from Hell";
 		changeClan();
 	}
-	if(oldClan == get_clan_id())
+	if(get_clan_name() != clanName)
 	{
 		set_property("_clanFortuneConsultUses", 42069);
 		return false;

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1531,7 +1531,7 @@ boolean makeGenieWish(effect eff)
 	return true;
 }
 
-boolean makeGenieCombat(monster mon, string option)
+boolean canGenieCombat()
 {
 	if(item_amount($item[Genie Bottle]) == 0)
 	{
@@ -1546,6 +1546,15 @@ boolean makeGenieCombat(monster mon, string option)
 		return false;
 	}
 	if(my_adventures() == 0)
+	{
+		return false;
+	}
+	return true;
+}
+
+boolean makeGenieCombat(monster mon, string option)
+{
+	if(!canGenieCombat())
 	{
 		return false;
 	}


### PR DESCRIPTION
Also closes #145, in the sense that we now use those specific items listed (Sea Shawl, wax hand, and chalk chapeau).
Closes #63 (use genie for ore and lobsterfrogman) because we're, uh, already using genie wishes and I don't want to write a config for that, sorry?

**spurious issues:**
Closes #138 because it was a salad day bug
Closes #98 because, although it's janky, fixing it wouldn't change script behavior.
Closes #89 because no repro steps given