### PR TITLE
[vampyre] Fix running from initial noncombat

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_batpath.ash
+++ b/RELEASE/scripts/sl_ascend/sl_batpath.ash
@@ -300,7 +300,9 @@ void bat_reallyPickSkills(int hpLeft)
 
 void bat_reallyPickSkills(int hpLeft, boolean[skill] requiredSkills)
 {
-	if(my_class() != $class[Vampyre])
+	// Why Astral Spirit? When entering a DG run, before exiting the initial
+	// noncombat and Torpor, that's what KoLmafia thinks you are.
+	if(my_class() != $class[Vampyre] && to_string(my_class()) != "Astral Spirit")
 	{
 		return;
 	}


### PR DESCRIPTION
When we start a Vampyre run, KoLmafia thinks we're an Astral Spirit until we leave the opening Torpor adventure. If we expect to be a Vampyre during skill selection, we won't select our opening skills properly.