### PR TITLE
Do Spookyraven Cellar before lengthy Talisman O' Nam quest

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -14365,9 +14365,9 @@ boolean doTasks()
 	if(Lsc_flyerSeals())				return true;
 	if(L11_blackMarket())				return true;
 	if(L11_forgedDocuments())			return true;
+	if(L11_mauriceSpookyraven())		return true;
 	if(L11_mcmuffinDiary())				return true;
 	if(L11_talismanOfNam())				return true;
-	if(L11_mauriceSpookyraven())		return true;
 	if(L11_nostrilOfTheSerpent())		return true;
 	if(L11_unlockHiddenCity())			return true;
 	if(L11_hiddenCityZones())			return true;

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -14365,8 +14365,8 @@ boolean doTasks()
 	if(Lsc_flyerSeals())				return true;
 	if(L11_blackMarket())				return true;
 	if(L11_forgedDocuments())			return true;
-	if(L11_mauriceSpookyraven())		return true;
 	if(L11_mcmuffinDiary())				return true;
+	if(L11_mauriceSpookyraven())		return true;
 	if(L11_talismanOfNam())				return true;
 	if(L11_nostrilOfTheSerpent())		return true;
 	if(L11_unlockHiddenCity())			return true;


### PR DESCRIPTION
This brings better booze into your route earlier for Dark Gyfte. Shouldn't have any adverse effect on other paths.