### PR TITLE
[NEP] Decline quests to keep the party going

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_mr2018.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2018.ash
@@ -705,7 +705,7 @@ boolean neverendingPartyCombat(effect eff, boolean hardmode, string option, bool
 	fightClubSpa();
 	//May need to actually have 1 adventure left.
 
-	backupSetting("choiceAdventure1322", 1);
+	backupSetting("choiceAdventure1322", 2);
 
 	switch(eff)
 	{


### PR DESCRIPTION
This prevents the quest from being accidentally completed. Plus, as pointed out by @xande-1, it means you don't lose meat if the DJ quest rolls around.

Fixes #164 