### PR TITLE
[vampyre] Farm a small number of dieting pills

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -9260,7 +9260,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
 
-		if(have_skill($skill[Flock of Bats Form]) && have_skill($skill[Sharp Eyes])))
+		if(!bat_wantHowl($location[The Defiled Cranny]) && have_skill($skill[Flock of Bats Form]) && have_skill($skill[Sharp Eyes]))
 		{
 			boolean desired_pills = in_hardcore() ? 6 : 4;
 			if(item_amount($item[dieting pill]) < desired_pills)

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -9262,7 +9262,7 @@ boolean L7_crypt()
 
 		if(!bat_wantHowl($location[The Defiled Cranny]) && have_skill($skill[Flock of Bats Form]) && have_skill($skill[Sharp Eyes]))
 		{
-			boolean desired_pills = in_hardcore() ? 6 : 4;
+			int desired_pills = in_hardcore() ? 6 : 4;
 			if(item_amount($item[dieting pill]) < desired_pills)
 			{
 				bat_formBats();

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -9259,6 +9259,16 @@ boolean L7_crypt()
 		{
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
+
+		if(have_skill($skill[Flock of Bats Form]) && have_skill($skill[Sharp Eyes])))
+		{
+			boolean desired_pills = in_hardcore() ? 6 : 4;
+			if(item_amount($item[dieting pill]) < desired_pills)
+			{
+				bat_formBats();
+				set_property("choiceAdventure523", "5");
+			}
+		}
 		buffMaintain($effect[Ceaseless Snarling], 0, 1, 1);
 		providePlusNonCombat(25);
 		ccAdv(1, $location[The Defiled Cranny]);


### PR DESCRIPTION
Resolves #139, although it doesn't 100% block the swarm. Just blocks it until we have a small stash of pills. Logic implemented literally as @jaspercb had suggested, thank you for that :)

Speaking for myself, I can't cap the 10% drop rate for dieting pills. So this could actually take a lot of combats. Should we try to buff item drop in other ways? It's probably not worth using up Champagne Bottle charges, but if there's a simple +item optimizer for equipment/cheap spleen items I'd use that.

Also, it doesn't track drops that have been received and then used. Kind of a niche failure mode, but you only want to eat two pills per day, so it should only delay your run by the time taken to get two more pills.

**Edit**: Still needs testing btw. Not sure if I'll reach level 8 today, if not will try it tomorrow.