### PR TITLE
Do not attempt to instakill ancient protector spirits without a scroll

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -1180,6 +1180,15 @@ string sl_combatHandler(int round, string opp, string text)
 			doInstaKill = false;
 		}
 	}
+					  
+	if ($monster[ancient protector spirit] == enemy && canUse($item[scroll of ancient forbidden unspeakable evil]))
+	{
+		return useItem($item[scroll of ancient forbidden unspeakable evil]);
+	}
+	else
+	{
+		doInstaKill = false;
+	}
 
 	if(instakillable(enemy) && !isFreeMonster(enemy) && doInstaKill)
 	{


### PR DESCRIPTION
I'm not sure about the exact mechanics of instakilling ancient protector spirits and mafia doesn't mark them as bosses, but you definitely can't use Chest X-Ray for example.

This may be a mafia issue. I'll try to check with a dataspider.