### PR TITLE
NEP free fights no longer throw off stall detection

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -8718,9 +8718,6 @@ boolean LX_freeCombats()
 
 	if((sl_my_path() != "Disguises Delimit") && neverendingPartyCombat())
 	{
-		loopHandlerDelay("_sl_lastABooCycleFix");
-		loopHandlerDelay("_sl_digitizeDeskCounter");
-		loopHandlerDelay("_sl_digitizeAssassinCounter");
 		return true;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_mr2018.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2018.ash
@@ -758,6 +758,12 @@ boolean neverendingPartyCombat(effect eff, boolean hardmode, string option, bool
 		retval = ccAdv(1, $location[The Neverending Party], option);
 	}
 
+	if(retval)
+	{
+		loopHandlerDelay("_sl_lastABooCycleFix");
+		loopHandlerDelay("_sl_digitizeDeskCounter");
+		loopHandlerDelay("_sl_digitizeAssassinCounter");
+	}
 
 	restoreSetting("choiceAdventure1322");
 	restoreSetting("choiceAdventure1324");


### PR DESCRIPTION
This fixes "We are in an A-Boo Peak cycle and can't find anything else to do. Aborting. If you have actual other quests left, please report this. Otherwise, complete A-Boo peak manually"

TL;DR when we used free fights in the NEP to powerlevel, we weren't adjusting the loop counter. After 5 or 6 adventures, we'd hit the 5-turn cutoff of the a-boo peak loop detector and abort.

Closes #144