### PR TITLE
Fix Liana stall detection, fix a-boo peak deaths when already under Mist Form

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -11904,17 +11904,20 @@ boolean L9_aBooPeak()
 			spookyResist += 2;
 		}
 
-		if(have_skill($skill[Mist Form]))
+		if(0 == have_effect($effect[Mist Form]))
 		{
-			coldResist += 4;
-			spookyResist += 4;
-			effectiveCurrentHP -= 10;
-		}
-		else if(have_skill($skill[Spectral Awareness]))
-		{
-			coldResist += 2;
-			spookyResist += 2;
-			effectiveCurrentHP -= 10;
+			if(have_skill($skill[Mist Form]))
+			{
+				coldResist += 4;
+				spookyResist += 4;
+				effectiveCurrentHP -= 10;
+			}
+			else if(have_skill($skill[Spectral Awareness]))
+			{
+				coldResist += 2;
+				spookyResist += 2;
+				effectiveCurrentHP -= 10;
+			}
 		}
 
 		if((item_amount($item[Spooky Powder]) > 0) && (have_effect($effect[Spookypants]) == 0))

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -11912,7 +11912,7 @@ boolean L9_aBooPeak()
 				spookyResist += 4;
 				effectiveCurrentHP -= 10;
 			}
-			else if(have_skill($skill[Spectral Awareness]))
+			else if(have_skill($skill[Spectral Awareness]) && (0 == have_effect($effect[Spectral Awareness])))
 			{
 				coldResist += 2;
 				spookyResist += 2;

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -5115,9 +5115,7 @@ boolean L13_towerNSEntrance()
 			{
 				doRest();
 				cli_execute("scripts/postsool.ash");
-				loopHandlerDelay("_sl_lastABooCycleFix");
-				loopHandlerDelay("_sl_digitizeDeskCounter");
-				loopHandlerDelay("_sl_digitizeAssassinCounter");
+				loopHandlerDelayAll();
 				return true;
 			}
 
@@ -5941,6 +5939,7 @@ boolean L11_hiddenCityZones()
 
 		set_property("choiceAdventure781", "1");
 		ccAdv(1, $location[An Overgrown Shrine (Northwest)]);
+		loopHandlerDelayAll();
 		if(contains_text(get_property("lastEncounter"), "Earthbound and Down"))
 		{
 			set_property("sl_hiddenzones", "2");
@@ -5976,6 +5975,7 @@ boolean L11_hiddenCityZones()
 
 		set_property("choiceAdventure785", "1");
 		ccAdv(1, $location[An Overgrown Shrine (Northeast)]);
+		loopHandlerDelayAll();
 		if(contains_text(get_property("lastEncounter"), "Air Apparent"))
 		{
 			set_property("sl_hiddenzones", "3");
@@ -6012,6 +6012,7 @@ boolean L11_hiddenCityZones()
 
 		set_property("choiceAdventure783", "1");
 		ccAdv(1, $location[An Overgrown Shrine (Southwest)]);
+		loopHandlerDelayAll();
 		if(contains_text(get_property("lastEncounter"), "Water You Dune"))
 		{
 			set_property("sl_hiddenzones", "4");
@@ -6048,6 +6049,7 @@ boolean L11_hiddenCityZones()
 
 		set_property("choiceAdventure787", "1");
 		ccAdv(1, $location[An Overgrown Shrine (Southeast)]);
+		loopHandlerDelayAll();
 		if(contains_text(get_property("lastEncounter"), "Fire When Ready"))
 		{
 			set_property("sl_hiddenzones", "5");
@@ -8746,9 +8748,7 @@ boolean LX_freeCombats()
 		set_property("choiceAdventure1119", get_property("sl_choice1119"));
 		set_property("sl_choice1119", "");
 		handleFamiliar("item");
-		loopHandlerDelay("_sl_lastABooCycleFix");
-		loopHandlerDelay("_sl_digitizeDeskCounter");
-		loopHandlerDelay("_sl_digitizeAssassinCounter");
+		loopHandlerDelayAll();
 		return true;
 	}
 
@@ -8761,10 +8761,7 @@ boolean LX_freeCombats()
 		{
 			set_property("_sl_digitizeDeskCounter", get_property("_sl_digitizeDeskCounter").to_int() - 1);
 		}
-		loopHandlerDelay("_sl_lastABooCycleFix");
-		loopHandlerDelay("_sl_digitizeDeskCounter");
-		loopHandlerDelay("_sl_digitizeAssassinCounter");
-
+		loopHandlerDelayAll();
 		return true;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -710,6 +710,7 @@ boolean loopHandler(string turnSetting, string counterSetting, int threshold);//
 boolean loopHandler(string turnSetting, string counterSetting, string abortMessage, int threshold);//Defined in sl_ascend/sl_util.ash
 boolean loopHandlerDelay(string counterSetting);			//Defined in sl_ascend/sl_util.ash
 boolean loopHandlerDelay(string counterSetting, int threshold);//Defined in sl_ascend/sl_util.ash
+boolean loopHandlerDelayAll();								// Defined in sl_ascend/sl_util.ash
 boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int loveEffect, boolean equivocator, int giftItem);//Defined in sl_ascend/sl_mr2017.ash
 boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int loveEffect, boolean equivocator, int giftItem, string option);//Defined in sl_ascend/sl_mr2017.ash
 boolean pantogramPants();									//Defined in sl_ascend/sl_mr2017.ash

--- a/RELEASE/scripts/sl_ascend/sl_mr2018.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2018.ash
@@ -760,9 +760,7 @@ boolean neverendingPartyCombat(effect eff, boolean hardmode, string option, bool
 
 	if(retval)
 	{
-		loopHandlerDelay("_sl_lastABooCycleFix");
-		loopHandlerDelay("_sl_digitizeDeskCounter");
-		loopHandlerDelay("_sl_digitizeAssassinCounter");
+		loopHandlerDelayAll();
 	}
 
 	restoreSetting("choiceAdventure1322");

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -803,6 +803,14 @@ boolean loopHandlerDelay(string counterSetting, int threshold)
 	return false;
 }
 
+boolean loopHandlerDelayAll()
+{
+	boolean boo = loopHandlerDelay("_sl_lastABooCycleFix");
+	boolean desk = loopHandlerDelay("_sl_digitizeDeskCounter");
+	boolean digitize = loopHandlerDelay("_sl_digitizeAssassinCounter");
+	return boo || desk || digitize;
+}
+
 boolean is100FamiliarRun()
 {
 	// Answers the question "am I not allowed to change my familiar?"


### PR DESCRIPTION
Now that we use Mist Form aggressively for other quests (e.g. to get enough +stench res for ), we're running into an issue where we effectively double-counted mist form's +4 resistance when considering a-boo peak. This lead to deaths at a-boo peak, which were sad.

Also, free liana fights (when a machete is equipped) were throwing off infinite loop detection.