### PR TITLE
Add Fourth of May Cosplay Saber to weapon picker

### DIFF
--- a/BUILD/equipment/weapon.dat
+++ b/BUILD/equipment/weapon.dat
@@ -18,6 +18,7 @@ Lead Pipe	class:Seal Clubber
 Fish Hatchet
 Bass Clarinet
 # We now resume the previous club broadcast
+Fourth of May Cosplay Saber	class:Seal Clubber	skill:Iron Palms
 Porcelain Police Baton	class:Seal Clubber
 Stainless Steel Shillelagh	class:Seal Clubber
 Frozen Seal Spine	class:Seal Clubber
@@ -61,6 +62,8 @@ revolver	mainstat:Moxie
 knife	mainstat:Moxie
 # Autohits? Yes please.
 Thor's Pliers
+# The Saber uses your highest stat for attacks
+Fourth of May Cosplay Saber
 # Nice ultra rare you got there
 The Nuge's favorite crossbow	mainstat:Moxie
 # Vampyres are a Mysticality class that sometimes can't use spells. Ugh.

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -353,101 +353,104 @@ weapon	8	Lead Pipe	class:Seal Clubber
 weapon	9	Fish Hatchet
 weapon	10	Bass Clarinet
 # We now resume the previous club broadcast
-weapon	11	Porcelain Police Baton	class:Seal Clubber
-weapon	12	Stainless Steel Shillelagh	class:Seal Clubber
-weapon	13	Frozen Seal Spine	class:Seal Clubber
-weapon	14	Ghast Iron Cleaver	class:Seal Clubber
-weapon	15	Oversized Pipe	class:Seal Clubber
-weapon	16	Curmudgel	class:Seal Clubber
-weapon	17	Elegant Nightstick	class:Seal Clubber
-weapon	18	Maxwell's Silver Hammer	class:Seal Clubber
-weapon	19	Red Hot Poker	class:Seal Clubber
-weapon	20	Giant Foam Finger	class:Seal Clubber
-weapon	21	Hilarious Comedy Prop	class:Seal Clubber
-weapon	22	Infernal Toilet Brush	class:Seal Clubber
-weapon	23	Mannequin Leg	class:Seal Clubber
-weapon	24	Gnawed-Up Dog Bone	class:Seal Clubber
-weapon	25	Severed Flipper	class:Seal Clubber
-weapon	26	Spiked Femur	class:Seal Clubber
-weapon	27	Corrupt Club of Corrupt Corruption	class:Seal Clubber
-weapon	28	Kneecapping Stick	class:Seal Clubber
-weapon	29	Orcish frat-paddle	class:Seal Clubber
-weapon	30	Flaming Crutch	class:Seal Clubber
-weapon	31	Corrupt Club of Corruption	class:Seal Clubber
-weapon	32	Skeleton Bone	class:Seal Clubber
-weapon	33	Remaindered Axe	class:Seal Clubber
-weapon	34	Club of Corruption	class:Seal Clubber
-weapon	35	Gnollish Flyswatter	class:Seal Clubber
-weapon	36	Seal-Clubbing Club	class:Seal Clubber
+weapon	11	Fourth of May Cosplay Saber	class:Seal Clubber	skill:Iron Palms
+weapon	12	Porcelain Police Baton	class:Seal Clubber
+weapon	13	Stainless Steel Shillelagh	class:Seal Clubber
+weapon	14	Frozen Seal Spine	class:Seal Clubber
+weapon	15	Ghast Iron Cleaver	class:Seal Clubber
+weapon	16	Oversized Pipe	class:Seal Clubber
+weapon	17	Curmudgel	class:Seal Clubber
+weapon	18	Elegant Nightstick	class:Seal Clubber
+weapon	19	Maxwell's Silver Hammer	class:Seal Clubber
+weapon	20	Red Hot Poker	class:Seal Clubber
+weapon	21	Giant Foam Finger	class:Seal Clubber
+weapon	22	Hilarious Comedy Prop	class:Seal Clubber
+weapon	23	Infernal Toilet Brush	class:Seal Clubber
+weapon	24	Mannequin Leg	class:Seal Clubber
+weapon	25	Gnawed-Up Dog Bone	class:Seal Clubber
+weapon	26	Severed Flipper	class:Seal Clubber
+weapon	27	Spiked Femur	class:Seal Clubber
+weapon	28	Corrupt Club of Corrupt Corruption	class:Seal Clubber
+weapon	29	Kneecapping Stick	class:Seal Clubber
+weapon	30	Orcish frat-paddle	class:Seal Clubber
+weapon	31	Flaming Crutch	class:Seal Clubber
+weapon	32	Corrupt Club of Corruption	class:Seal Clubber
+weapon	33	Skeleton Bone	class:Seal Clubber
+weapon	34	Remaindered Axe	class:Seal Clubber
+weapon	35	Club of Corruption	class:Seal Clubber
+weapon	36	Gnollish Flyswatter	class:Seal Clubber
+weapon	37	Seal-Clubbing Club	class:Seal Clubber
 # Some okay stuff for Turtle Tamers
-weapon	37	Garbage Sticker	class:Turtle Tamer
-weapon	38	Work Is A Four Letter Sword	class:Turtle Tamer
+weapon	38	Garbage Sticker	class:Turtle Tamer
+weapon	39	Work Is A Four Letter Sword	class:Turtle Tamer
 # Smiths weapons for the other classes
-weapon	39	Saucepanic	class:Sauceror
-weapon	40	Hand That Rocks The Ladle	class:Pastamancer
-weapon	41	Frankly Mr. Shank	class:Disco Bandit
-weapon	42	Shakespeare's Sister's Accordion	class:Accordion Thief
+weapon	40	Saucepanic	class:Sauceror
+weapon	41	Hand That Rocks The Ladle	class:Pastamancer
+weapon	42	Frankly Mr. Shank	class:Disco Bandit
+weapon	43	Shakespeare's Sister's Accordion	class:Accordion Thief
 # Good stuff but less good than Smithsness
-weapon	43	Sneaky Pete's Basket	class:Avatar of Sneaky Pete
-weapon	44	Rope	mainstat:Muscle
-weapon	45	Lead Pipe	mainstat:Muscle
-weapon	46	accord ion	class:Accordion Thief
-weapon	47	revolver	mainstat:Moxie
-weapon	48	knife	mainstat:Moxie
+weapon	44	Sneaky Pete's Basket	class:Avatar of Sneaky Pete
+weapon	45	Rope	mainstat:Muscle
+weapon	46	Lead Pipe	mainstat:Muscle
+weapon	47	accord ion	class:Accordion Thief
+weapon	48	revolver	mainstat:Moxie
+weapon	49	knife	mainstat:Moxie
 # Autohits? Yes please.
-weapon	49	Thor's Pliers
+weapon	50	Thor's Pliers
+# The Saber uses your highest stat for attacks
+weapon	51	Fourth of May Cosplay Saber
 # Nice ultra rare you got there
-weapon	50	The Nuge's favorite crossbow	mainstat:Moxie
+weapon	52	The Nuge's favorite crossbow	mainstat:Moxie
 # Vampyres are a Mysticality class that sometimes can't use spells. Ugh.
-weapon	51	disco ball	class:Vampyre;skill:Sinister Charm;effect:Bats Form;!skill:Piercing Gaze
-weapon	52	disco ball	class:Vampyre;skill:Sinister Charm;effect:Wolf Form;!skill:Savage Bite
-weapon	53	disco ball	class:Vampyre;skill:Sinister Charm;!skill:Chill of the Tomb
+weapon	53	disco ball	class:Vampyre;skill:Sinister Charm;effect:Bats Form;!skill:Piercing Gaze
+weapon	54	disco ball	class:Vampyre;skill:Sinister Charm;effect:Wolf Form;!skill:Savage Bite
+weapon	55	disco ball	class:Vampyre;skill:Sinister Charm;!skill:Chill of the Tomb
 # Some more stuff. It's okay, I guess
-weapon	54	The Jokester's Gun	mainstat:Moxie
-weapon	55	world's smallest violin	mainstat:Moxie
-weapon	56	Frigid Derringer	mainstat:Moxie
-weapon	57	witty rapier	mainstat:Mysticality
-weapon	58	Chopsticks	mainstat:Mysticality
-weapon	59	Oversized Pizza Cutter	mainstat:Mysticality
-weapon	60	Eggbeater	mainstat:Mysticality
-weapon	61	Corn Holder	mainstat:Mysticality
-weapon	62	Dishrag	mainstat:Mysticality
+weapon	56	The Jokester's Gun	mainstat:Moxie
+weapon	57	world's smallest violin	mainstat:Moxie
+weapon	58	Frigid Derringer	mainstat:Moxie
+weapon	59	witty rapier	mainstat:Mysticality
+weapon	60	Chopsticks	mainstat:Mysticality
+weapon	61	Oversized Pizza Cutter	mainstat:Mysticality
+weapon	62	Eggbeater	mainstat:Mysticality
+weapon	63	Corn Holder	mainstat:Mysticality
+weapon	64	Dishrag	mainstat:Mysticality
 # Good knives
-weapon	63	black blade	mainstat:Moxie;skill:Tricky Knifework
-weapon	64	batblade	mainstat:Moxie;skill:Tricky Knifework
-weapon	65	soap knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	66	Saturday Night Special	mainstat:Moxie
+weapon	65	black blade	mainstat:Moxie;skill:Tricky Knifework
+weapon	66	batblade	mainstat:Moxie;skill:Tricky Knifework
+weapon	67	soap knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	68	Saturday Night Special	mainstat:Moxie
 # Knives that are fine
-weapon	67	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
-weapon	68	candy knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	69	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
-weapon	70	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
-weapon	71	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
+weapon	69	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
+weapon	70	candy knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	71	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
+weapon	72	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
+weapon	73	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
 # This stuff is definitely better than garbage
-weapon	72	finger cymbals	mainstat:Moxie
+weapon	74	finger cymbals	mainstat:Moxie
 # The worst knife, but it's still a knife
-weapon	73	boot knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	74	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	75	boot knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	76	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
 # It's not good, but at least it's a ranged weapon that takes one hand
-weapon	75	disco ball	mainstat:Moxie
-weapon	76	stolen accordion	class:Accordion Thief
+weapon	77	disco ball	mainstat:Moxie
+weapon	78	stolen accordion	class:Accordion Thief
 # Some melee weapons
-weapon	77	Rusty Piece Of Rebar
-weapon	78	Octopus's Spade
-weapon	79	Oversized Pipe
-weapon	80	Ghast Iron Cleaver
-weapon	81	Short-Handled Mop
-weapon	82	Spectral Axe
-weapon	83	Antique Machete
-weapon	84	red-hot sausage fork
+weapon	79	Rusty Piece Of Rebar
+weapon	80	Octopus's Spade
+weapon	81	Oversized Pipe
+weapon	82	Ghast Iron Cleaver
+weapon	83	Short-Handled Mop
+weapon	84	Spectral Axe
+weapon	85	Antique Machete
+weapon	86	red-hot sausage fork
 # Almost absolute garbage
-weapon	85	Skeleton Bone
-weapon	86	Corn Holder
-weapon	87	Knob Goblin Scimitar
-weapon	88	Knob Goblin Tongs
+weapon	87	Skeleton Bone
+weapon	88	Corn Holder
+weapon	89	Knob Goblin Scimitar
+weapon	90	Knob Goblin Tongs
 # Absolute garbage, but better than nothing, probably?
-weapon	89	Turtle Totem	class:Turtle Tamer
-weapon	90	Saucepan	class:Sauceror
-weapon	91	Pasta Spoon	class:Pastamancer
+weapon	91	Turtle Totem	class:Turtle Tamer
+weapon	92	Saucepan	class:Sauceror
+weapon	93	Pasta Spoon	class:Pastamancer
 # I probably missed some stuff from the old weapon handling but c'est la vie
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1,6 +1,6 @@
 script "sl_ascend.ash";
 notify soolar the second;
-since r19153; // Orcish frat-paddle
+since r19205; // Initial Saber support
 /***
 	svn checkout https://svn.code.sf.net/p/ccascend/code/sl_ascend
 	Killing is wrong, and bad. There should be a new, stronger word for killing like badwrong or badong. YES, killing is badong. From this moment, I will stand for the opposite of killing, gnodab.


### PR DESCRIPTION
Note that it uses your highest stat for attacks according to http://kol.coldfront.net/thekolwiki/index.php/Fourth_of_May_Cosplay_Saber, so the only finicky logic is seal clubbers wanting to be able to club.

Closes #203