### PR TITLE
[accordionthief] Use Saucestorm when non-mox weapon equipped

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -1586,7 +1586,7 @@ string sl_combatHandler(int round, string opp, string text)
 			costStunner = mp_cost($skill[Shell Up]);
 		}
 
-		if(((monster_defense() - my_buffedstat(my_primestat())) > 20) && canUse($skill[Saucestorm], false))
+		if(((monster_defense() - my_buffedstat(weapon_type(equipped_item($slot[Weapon])))) > 20) && canUse($skill[Saucestorm], false))
 		{
 			attackMajor = useSkill($skill[Saucestorm], false);
 			costMajor = mp_cost($skill[Saucestorm]);


### PR DESCRIPTION
I guess we technically still want to attack if we're holding the Saber or another versatile weapon, but that's a problem for later.

Fixes #204