### PR TITLE
Some Copperhead and Ed changes

### DIFF
--- a/BUILD/equipment/off-hand.dat
+++ b/BUILD/equipment/off-hand.dat
@@ -26,6 +26,7 @@ Keg Shield
 Wicker Shield
 Sawblade Shield
 Yorick
+Red X Shield
 Party Crasher
 Spiked Femur
 Hot Plate

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ jaspercb (IGN: Jeparo (#2246666))
 
 MatthewDarling (IGN: MasterAssasin (#613216))
 
+Malibu Stacey (IGN: Malibu Stacey (#2705901))
+
 ## Special Thanks
 
 This script would obviously not be possible without the work of Cheesecookie.

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -240,15 +240,16 @@ off-hand	23	Keg Shield
 off-hand	24	Wicker Shield
 off-hand	25	Sawblade Shield
 off-hand	26	Yorick
-off-hand	27	Party Crasher
-off-hand	28	Spiked Femur
-off-hand	29	Hot Plate
-off-hand	30	Oversized Pizza Cutter
-off-hand	31	Cardboard Wakizashi
-off-hand	32	Pitchfork
-off-hand	33	Sabre Teeth
-off-hand	34	Knob Goblin Scimitar
-off-hand	35	Turtle Totem
+off-hand	27	Red X Shield
+off-hand	28	Party Crasher
+off-hand	29	Spiked Femur
+off-hand	30	Hot Plate
+off-hand	31	Oversized Pizza Cutter
+off-hand	32	Cardboard Wakizashi
+off-hand	33	Pitchfork
+off-hand	34	Sabre Teeth
+off-hand	35	Knob Goblin Scimitar
+off-hand	36	Turtle Totem
 
 # Good ol' pants
 pants	0	Pantsgiving

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1751,9 +1751,6 @@ void initializeDay(int day)
 		sl_saberChoice("res");
 	}
 
-	cli_execute("ccs null");
-	set_property("battleAction", "custom combat script");
-
 	if((item_amount($item[cursed microwave]) >= 1) && !get_property("_cursedMicrowaveUsed").to_boolean())
 	{
 		use(1, $item[cursed microwave]);
@@ -14640,6 +14637,8 @@ void sl_begin()
 	backupSetting("manaBurningThreshold", -1);
 
 	backupSetting("currentMood", "apathetic");
+	backupSetting("customCombatScript", "null");
+	backupSetting("battleAction", "custom combat script");
 
 	backupSetting("choiceAdventure1107", 1);
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -4950,7 +4950,7 @@ boolean L13_towerNSContests()
 					makeGenieWish($effect[Sewer-Drenched]);
 					break;
 				case $element[spooky]:
-					makeGenieWish($effect[You're Back...]);
+					makeGenieWish($effect[You\'re Back...]);
 					break;
 				}
 			}
@@ -6155,7 +6155,7 @@ boolean L11_unlockHiddenCity()
 				handleFamiliar("item");
 				if((numeric_modifier("item drop") >= 100))
 				{
-					if (!makeGenieCombat($monster[Baa'baa'bu'ran]) || item_amount($item[Stone Wool]) == 0)
+					if (!makeGenieCombat($monster[Baa\'baa\'bu\'ran]) || item_amount($item[Stone Wool]) == 0)
 					{
 						print("Wishing for stone wool failed.", "red");
 					}
@@ -12817,7 +12817,7 @@ boolean L11_redZeppelin()
 			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
 			makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
 		}
-		float fire_protestors = item_amount($item[Flamin' Whatshisname]) > 0 ? 10 : 3;
+		float fire_protestors = item_amount($item[Flamin\' Whatshisname]) > 0 ? 10 : 3;
 		float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");
 		float sleaze_protestors = square_root(sleaze_amount);
 		float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
@@ -12908,7 +12908,13 @@ boolean L11_ronCopperhead()
 		}
 		// For Glark Cables. OPTIMAL!
 		bat_formBats();
-		return ccAdv($location[The Red Zeppelin]);
+		boolean retval = ccAdv($location[The Red Zeppelin]);
+		// open red boxes when we get them (not sure if this is the place for this but it'll do for now)
+		if (item_amount($item[red box]) > 0)
+		{
+			use (item_amount($item[red box]), $item[red box])
+		}
+		return retval;
 	}
 
 	if(get_property("questL11Ron") != "finished")
@@ -13001,9 +13007,24 @@ boolean L11_shenCopperhead()
 				}
 			}
 		}
+
 		if(!zone_isAvailable(goal))
+		{
+			// handle paths which don't need Tower keys but the World's Biggest Jerk asks for The Eye of the Stars
+			if (goal == $location[The Hole in the Sky])
+			{
+				if (!get_property("sl_holeinthesky").to_boolean())
+				{
+					set_property("sl_holeinthesky", true);
+				}
+				return L10_holeInTheSkyUnlock();
+			}
 			return false;
-		return ccAdv(goal);
+		}
+		else
+		{
+			return ccAdv(goal);
+		}
 	}
 
 	if(get_property("questL11Shen") != "finished")
@@ -14617,6 +14638,8 @@ void sl_begin()
 	backupSetting("mpAutoRecoveryTarget", -1);
 	backupSetting("manaBurningTrigger", -1);
 	backupSetting("manaBurningThreshold", -1);
+
+	backupSetting("currentMood", "apathetic");
 
 	backupSetting("choiceAdventure1107", 1);
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12909,7 +12909,7 @@ boolean L11_ronCopperhead()
 		// open red boxes when we get them (not sure if this is the place for this but it'll do for now)
 		if (item_amount($item[red box]) > 0)
 		{
-			use (item_amount($item[red box]), $item[red box])
+			use (item_amount($item[red box]), $item[red box]);
 		}
 		return retval;
 	}

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -2635,7 +2635,7 @@ string sl_edCombatHandler(int round, string opp, string text)
 
 	if(!contains_text(edCombatState, "curseofstench") && sl_have_skill($skill[Curse Of Stench]) && (my_mp() >= 35) && (get_property("stenchCursedMonster") != opp) && (get_property("sl_edCombatStage").to_int() < 3))
 	{
-		if($monsters[Bob Racecar, Cabinet of Dr. Limpieza, Dairy Goat, Dirty Old Lihc, Government Scientist,  Green Ops Soldier, Possessed Wine Rack, Pygmy Bowler, Pygmy Witch Surgeon, Quiet Healer, Racecar Bob, Writing Desk, Blue Oyster cultist] contains enemy)
+		if(sl_wantToSniff(enemy, my_location()))
 		{
 			set_property("sl_edCombatHandler", combatState + "(curseofstench)");
 			handleTracker(enemy, $skill[Curse Of Stench], "sl_sniffs");

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -823,7 +823,7 @@ string sl_combatHandler(int round, string opp, string text)
 		return "item " + $item[military-grade fingernail clippers];
 	}
 
-	if((item_amount($item[military-grade fingernail clippers]) > 0)  && (enemy == $monster[one of Doctor Weirdeaux's creations]))
+	if((item_amount($item[military-grade fingernail clippers]) > 0)  && (enemy == $monster[one of Doctor Weirdeaux\'s creations]))
 	{
 		if(!haveUsed($item[military-grade fingernail clippers]))
 		{
@@ -1189,7 +1189,7 @@ string sl_combatHandler(int round, string opp, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
-		if(canUse($skill[Chest X-Ray]) && equipped_amount($item[Lil' Doctor&trade; bag]) > 0 && (get_property("_chestXRayUsed").to_int() < 3))
+		if(canUse($skill[Chest X-Ray]) && equipped_amount($item[Lil\' Doctor&trade; bag]) > 0 && (get_property("_chestXRayUsed").to_int() < 3))
 		{
 			if((my_adventures() < 20) || get_property("kingLiberated").to_boolean() || (my_daycount() >= 3))
 			{
@@ -1233,10 +1233,10 @@ string sl_combatHandler(int round, string opp, string text)
 			}
 		}
 
-		if(canUse($skill[Fire the Jokester's Gun]) && !get_property("_firedJokestersGun").to_boolean())
+		if(canUse($skill[Fire the Jokester\'s Gun]) && !get_property("_firedJokestersGun").to_boolean())
 		{
-			handleTracker(enemy, $skill[Fire the Jokester's Gun], "sl_instakill");
-			return useSkill($skill[Fire the Jokester's Gun]);
+			handleTracker(enemy, $skill[Fire the Jokester\'s Gun], "sl_instakill");
+			return useSkill($skill[Fire the Jokester\'s Gun]);
 		}
 	}
 
@@ -1430,7 +1430,7 @@ string sl_combatHandler(int round, string opp, string text)
 		}
 	}
 
-	if((my_location() == $location[Super Villain's Lair]) && (sl_my_path() == "License to Adventure") && canSurvive(2.0) && (enemy == $monster[Villainous Minion]))
+	if((my_location() == $location[Super Villain\'s Lair]) && (sl_my_path() == "License to Adventure") && canSurvive(2.0) && (enemy == $monster[Villainous Minion]))
 	{
 		if(!get_property("_villainLairCanLidUsed").to_boolean() && (item_amount($item[Razor-Sharp Can Lid]) > 0))
 		{
@@ -2340,7 +2340,7 @@ string sl_edCombatHandler(int round, string opp, string text)
 	set_property("sl_edCombatRoundCount", 1 + get_property("sl_edCombatRoundCount").to_int());
 
 
-	if(my_location() == $location[Hippy Camp])
+	if($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location())
 	{
 		if(!ed_needShop())
 		{
@@ -2635,7 +2635,7 @@ string sl_edCombatHandler(int round, string opp, string text)
 
 	if(!contains_text(edCombatState, "curseofstench") && sl_have_skill($skill[Curse Of Stench]) && (my_mp() >= 35) && (get_property("stenchCursedMonster") != opp) && (get_property("sl_edCombatStage").to_int() < 3))
 	{
-		if($monsters[Bob Racecar, Cabinet of Dr. Limpieza, Dairy Goat, Dirty Old Lihc, Government Scientist,  Green Ops Soldier, Possessed Wine Rack, Pygmy Bowler, Pygmy Witch Surgeon, Quiet Healer, Racecar Bob, Writing Desk] contains enemy)
+		if($monsters[Bob Racecar, Cabinet of Dr. Limpieza, Dairy Goat, Dirty Old Lihc, Government Scientist,  Green Ops Soldier, Possessed Wine Rack, Pygmy Bowler, Pygmy Witch Surgeon, Quiet Healer, Racecar Bob, Writing Desk, Blue Oyster cultist] contains enemy)
 		{
 			set_property("sl_edCombatHandler", combatState + "(curseofstench)");
 			handleTracker(enemy, $skill[Curse Of Stench], "sl_sniffs");
@@ -2790,20 +2790,21 @@ string sl_edCombatHandler(int round, string opp, string text)
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean wantCrude = ((oilProgress & 4) == 0);
-		if(item_amount($item[Bubblin\' Crude]) > 11)
-		{
-			wantCrude = false;
-		}
-		if(item_amount($item[Jar Of Oil]) > 0)
+		if(item_amount($item[Bubblin\' Crude]) > 11 || item_amount($item[Jar Of Oil]) > 0)
 		{
 			wantCrude = false;
 		}
 
-		
 		if(wantCrude)
 		{
 			return "item " + $item[Duskwalker Syringe];
 		}
+	}
+
+	if(my_location() == $location[A Mob Of Zeppelin Protesters] && item_amount($item[cigarette lighter]) > 0)
+	{
+		return "item " + $item[cigarette lighter];
+		// insta-kills protestors and removes an additional 5-7 (optimal!)
 	}
 
 	if(!contains_text(edCombatState, "lashofthecobra") && sl_have_skill($skill[Lash of the Cobra]) && (my_mp() >= 12))
@@ -3076,7 +3077,6 @@ string sl_edCombatHandler(int round, string opp, string text)
 
 	if(get_property("sl_edStatus") == "UNDYING!")
 	{
-#		if((my_location() == $location[The Secret Government Laboratory]) || !ed_needShop())
 		if(my_location() == $location[The Secret Government Laboratory])
 		{
 			if((item_amount($item[Rock Band Flyers]) == 0) && (item_amount($item[Jam Band Flyers]) == 0))
@@ -3100,8 +3100,6 @@ string sl_edCombatHandler(int round, string opp, string text)
 
 		if(item_amount($item[Dictionary]) > 0)
 		{
-#			string macro = "item dictionary; repeat";
-#			visit_url("fight.php?action=macro&macrotext=" + url_encode(macro), true, true);
 			return "item " + $item[Dictionary];
 		}
 		if(item_amount($item[Seal Tooth]) > 0)
@@ -3129,18 +3127,6 @@ string sl_edCombatHandler(int round, string opp, string text)
 		return "skill " + $skill[Fist Of The Mummy];
 	}
 
-
-#	if(!contains_text(combatState, "love stinkbug") && sl_have_skill($skill[Summon Love Stinkbug]) && (mcd <= 50))
-#	{
-#		set_property("sl_combatHandler", combatState + "(love stinkbug1)");
-#		return "skill " + $skill[Summon Love Stinkbug];
-#	}
-#	if(!contains_text(combatState, "love stinkbug") && get_property("lovebugsUnlocked").to_boolean() && (mcd <= 50))
-#	{
-#		set_property("sl_combatHandler", combatState + "(love stinkbug2)");
-#		return "skill " + $skill[Summon Love Stinkbug];
-#	}
-
 	int fightStat = my_buffedstat(weapon_type(equipped_item($slot[weapon]))) - 20;
 	if((fightStat > monster_defense()) && (round < 20) && canSurvive(1.1) && (get_property("sl_edStatus") == "UNDYING!"))
 	{
@@ -3157,14 +3143,14 @@ string sl_edCombatHandler(int round, string opp, string text)
 	{
 		return "item " + $item[Ice-Cold Cloaca Zero];
 	}
-	if((my_mp() >= 8) && sl_have_skill($skill[Storm Of The Scarab]) && (my_buffedstat($stat[Mysticality]) > 35))
+	if(my_mp() >= mp_cost($skill[Storm Of The Scarab]) && sl_have_skill($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) > 35)
 	{
 		return "skill " + $skill[Storm Of The Scarab];
 	}
 
 	if((enemy.physical_resistance >= 100) || (round >= 25) || canSurvive(1.25))
 	{
-		if((my_mp() >= 5) && sl_have_skill($skill[Fist Of The Mummy]))
+		if(my_mp() >= mp_cost($skill[Fist Of The Mummy]) && sl_have_skill($skill[Fist Of The Mummy]))
 		{
 			return "skill " + $skill[Fist Of The Mummy];
 		}

--- a/RELEASE/scripts/sl_ascend/sl_edTheUndying.ash
+++ b/RELEASE/scripts/sl_ascend/sl_edTheUndying.ash
@@ -813,7 +813,7 @@ boolean ed_eatStuff()
 			drinkSpeakeasyDrink($item[Lucky Lindy]);
 			#cli_execute("drink 1 lucky lindy");
 		}
-		else if((my_meat() >= npc_price($item[Fortune Cookie])) && (fullness_left() > 0) && (my_fullness() >= 4))
+		else if((my_meat() >= npc_price($item[Fortune Cookie])) && (fullness_left() > 0))
 		{
 			buyUpTo(1, $item[Fortune Cookie], npc_price($item[Fortune Cookie]));
 			ccEat(1, $item[Fortune Cookie]);
@@ -839,16 +839,11 @@ boolean ed_needShop()
 		return true;
 	}
 
-#	if(!get_property("lovebugsUnlocked").to_boolean() && (item_amount($item[Ka Coin]) >= 2) && (item_amount($item[Spirit Beer]) == 0) && (ed_spleen_limit() >= 35))
-	if(!get_property("lovebugsUnlocked").to_boolean() && (item_amount($item[Ka Coin]) >= 2) && (item_amount($item[Spirit Beer]) == 0) && (my_mp() < 100))
-	{
-		return true;
-	}
-
 	if(item_amount($item[Ka Coin]) < 15)
 	{
 		return false;
 	}
+  
 	int canEat = (spleen_limit() - my_spleen_use()) / 5;
 	canEat = max(0, canEat - item_amount($item[Mummified Beef Haunch]));
 
@@ -857,11 +852,6 @@ boolean ed_needShop()
 	{
 		limiter = $skill[Healing Scarabs];
 	}
-
-#	else if(my_daycount() > 2)
-#	{
-#		limiter = $skill[Upgraded Spine];
-#	}
 
 	if((canEat == 0) && have_skill(limiter) && (item_amount($item[Linen Bandages]) >= 4) && (get_property("sl_renenutetBought").to_int() >= 7) && (item_amount($item[Holy Spring Water]) >= 1) && (item_amount($item[Talisman of Horus]) >= 2))
 	{
@@ -909,7 +899,6 @@ boolean ed_shopping()
 		string temp = visit_url("peevpee.php?action=smashstone&pwd&confirm=on", true);
 		temp = visit_url("place.php?whichplace=edunder&action=edunder_hippy");
 		temp = visit_url("choice.php?pwd&whichchoice=1057&option=1", true);
-//		temp = visit_url("peevpee.php?place=fight");
 		set_property("sl_breakstone", false);
 	}
 
@@ -929,26 +918,18 @@ boolean ed_shopping()
 	}
 
 	//Limit mode: edunder
-	int canEat = 0;
-	if((my_spleen_use() + 5) <= ed_spleen_limit())
+	int canEat = (ed_spleen_limit() - my_spleen_use()) / 5;
+	canEat -= item_amount($item[Mummified Beef Haunch]);
+	while((coins >= 15) && (canEat > 0))
 	{
-		canEat = (ed_spleen_limit() - my_spleen_use()) / 5;
-		canEat = canEat - item_amount($item[Mummified Beef Haunch]);
-		while((coins >= 15) && (canEat > 0))
-		{
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=428", true);
-			print("Buying a mummified beef haunch!", "green");
-			coins = coins - 15;
-			canEat = canEat - 1;
-		}
+		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=428", true);
+		print("Buying a mummified beef haunch!", "green");
+		coins = coins - 15;
+		canEat = canEat - 1;
 	}
 
-#	if(!get_property("lovebugsUnlocked").to_boolean() && (item_amount($item[Ka Coin]) >= 2) && (item_amount($item[Spirit Beer]) == 0) && (ed_spleen_limit() >= 35))
-#	if(!get_property("lovebugsUnlocked").to_boolean() && (item_amount($item[Ka Coin]) >= 2) && (item_amount($item[Spirit Beer]) == 0) && (my_mp() < 100))
 	if(!get_property("lovebugsUnlocked").to_boolean() && (coins >= 2) && (item_amount($item[Holy Spring Water]) == 0) && (my_mp() < 15))
 	{
-#		print("Buying Spirit Beer", "green");
-#		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=432", true);
 		print("Buying Holy Spring Water", "green");
 		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
 		coins -= 1;


### PR DESCRIPTION
- open red boxes when we get them in the Red Zeppelin
- get the steam powered rocket ship if Shen requests the item from the Hole in the Sky and the path we're on doesn't need a Star Key
- backup current mood and set to apathetic on start-up
- add Red X Shield to off-hand equip list
- in Ed, treat Outskirts similar to Hippy Camp as we fail over to there when farming Ka to get legs and spleen upgrades
- in Ed, use cigarette lighters against zeppelin protestors
- in Ed, olfact the Blue Oyster Cultist to get more cigarette lighters
- other minor Ed changes/fixes.