### PR TITLE
 Add delay burning using Sausage Goblins

### DIFF
--- a/BUILD/equipment/acc.dat
+++ b/BUILD/equipment/acc.dat
@@ -51,6 +51,7 @@ Jolly Roger Charrrm Bracelet
 Grumpy Old Man Charrrm Bracelet
 Bonerdagon Necklace
 Batskin Belt
+shiny ring
 Garish Pinky Ring
 Ring Of Telling Skeletons What To Do
 Imp Unity Ring

--- a/BUILD/equipment/off-hand.dat
+++ b/BUILD/equipment/off-hand.dat
@@ -16,7 +16,7 @@ Trader Olaf's Exotic Stinkbeans	skill:Beancannon;!prop:_beancannonUses=5
 Pork 'n' Pork 'n' Pork 'n' Beans	skill:Beancannon;!prop:_beancannonUses=5
 Heimz Fortified Kidney Beans	skill:Beancannon;!prop:_beancannonUses=5
 Ouija Board, Ouija Board	class:Turtle Tamer
-Kramco Sausage-O-Matic&trade;
+Kramco Sausage-O-Matic&trade;	prop:_sausageFights>=7
 Operation Patriot Shield
 Ox-head Shield
 Latte Lovers Member's Mug
@@ -29,6 +29,7 @@ Yorick
 Red X Shield
 Party Crasher
 Spiked Femur
+Whatsian Ionic Pliers	class:Ed
 Hot Plate
 Oversized Pizza Cutter
 Cardboard Wakizashi

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -64,14 +64,15 @@ acc	48	Jolly Roger Charrrm Bracelet
 acc	49	Grumpy Old Man Charrrm Bracelet
 acc	50	Bonerdagon Necklace
 acc	51	Batskin Belt
-acc	52	Garish Pinky Ring
-acc	53	Ring Of Telling Skeletons What To Do
-acc	54	Imp Unity Ring
-acc	55	Infernal Insoles
-acc	56	Glowing Red Eye
-acc	57	Stuffed Shoulder Parrot
-acc	58	Vampire Collar
-acc	59	Jaunty Feather
+acc	52	shiny ring
+acc	53	Garish Pinky Ring
+acc	54	Ring Of Telling Skeletons What To Do
+acc	55	Imp Unity Ring
+acc	56	Infernal Insoles
+acc	57	Glowing Red Eye
+acc	58	Stuffed Shoulder Parrot
+acc	59	Vampire Collar
+acc	60	Jaunty Feather
 
 # Back items
 back	0	Protonic Accelerator Pack	expectghostreport:true
@@ -231,7 +232,7 @@ off-hand	13	Trader Olaf's Exotic Stinkbeans	skill:Beancannon;!prop:_beancannonUs
 off-hand	14	Pork 'n' Pork 'n' Pork 'n' Beans	skill:Beancannon;!prop:_beancannonUses=5
 off-hand	15	Heimz Fortified Kidney Beans	skill:Beancannon;!prop:_beancannonUses=5
 off-hand	16	Ouija Board, Ouija Board	class:Turtle Tamer
-off-hand	17	Kramco Sausage-O-Matic&trade;
+off-hand	17	Kramco Sausage-O-Matic&trade;	prop:_sausageFights>=7
 off-hand	18	Operation Patriot Shield
 off-hand	19	Ox-head Shield
 off-hand	20	Latte Lovers Member's Mug
@@ -244,13 +245,14 @@ off-hand	26	Yorick
 off-hand	27	Red X Shield
 off-hand	28	Party Crasher
 off-hand	29	Spiked Femur
-off-hand	30	Hot Plate
-off-hand	31	Oversized Pizza Cutter
-off-hand	32	Cardboard Wakizashi
-off-hand	33	Pitchfork
-off-hand	34	Sabre Teeth
-off-hand	35	Knob Goblin Scimitar
-off-hand	36	Turtle Totem
+off-hand	30	Whatsian Ionic Pliers	class:Ed
+off-hand	31	Hot Plate
+off-hand	32	Oversized Pizza Cutter
+off-hand	33	Cardboard Wakizashi
+off-hand	34	Pitchfork
+off-hand	35	Sabre Teeth
+off-hand	36	Knob Goblin Scimitar
+off-hand	37	Turtle Totem
 
 # Good ol' pants
 pants	0	Pantsgiving

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -645,6 +645,14 @@ boolean LX_burnDelay()
 				return true;
 			}
 		}
+		if(sl_sausageGoblin())
+		{
+			print("Burn some delay somewhere (sausage goblin), if we found a place!", "green");
+			if(sl_sausageGoblin(burnZone, ""))
+			{
+				return true;
+			}
+		}
 	}
 	return false;
 }

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -593,6 +593,9 @@ boolean sl_sausageGrind(int numSaus); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageGrind(int numSaus, boolean failIfCantMakeAll); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageEatEmUp(int maximumToEat); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_sausageEatEmUp(); // Defined in sl_ascend/sl_mr2019.ash
+boolean sl_sausageGoblin(); // Defined in sl_ascend/sl_mr2019.ash
+boolean sl_sausageGoblin(location loc); // Defined in sl_ascend/sl_mr2019.ash
+boolean sl_sausageGoblin(location loc, string option); // Defined in sl_ascend/sl_mr2019.ash
 boolean pirateRealmAvailable(); // Defined in sl_ascend/sl_mr2019.ash
 boolean LX_unlockPirateRealm(); // Defined in sl_ascend/sl_mr2019.ash
 boolean sl_saberChoice(string choice);	// Defined in sl_ascend/sl_mr2019.ash

--- a/RELEASE/scripts/sl_ascend/sl_mr2019.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2019.ash
@@ -159,6 +159,59 @@ boolean sl_sausageEatEmUp() {
 	return sl_sausageEatEmUp(0);
 }
 
+boolean sl_sausageGoblin()
+{
+	return sl_sausageGoblin($location[none], "");
+}
+
+boolean sl_sausageGoblin(location loc)
+{
+	return sl_sausageGoblin(loc, "");
+}
+
+boolean sl_sausageGoblin(location loc, string option)
+{
+	// Sausage Goblins have super low encounter priority so they will be overriden
+	// by all sorts stuff like superlikelies, wanderers and semi-rares.
+	// The good news is, being overridden just means adventure there again to get it
+
+	if(!possessEquipment($item[Kramco Sausage-o-Matic&trade;]))
+	{
+		return false;
+	}
+
+	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first 
+	// 7 sausage goblins using a formula of 3n+1 adventures since the previous.
+	// After that, you're on your own (hey it's better than nothing).
+	// Also that doesn't apply to the first goblin, it's always 100%.
+	int sausageFights = get_property("_sausageFights").to_int();
+	if (sausageFights >= 7)
+	{
+		return false;
+	}
+
+	int currentGoblinCeiling = (3 * (sausageFights + 1)) + 1;
+	if (sausageFights > 0 && (total_turns_played() - get_property("_lastSausageMonsterTurn").to_int()) < currentGoblinCeiling)
+	{
+		return false;
+	}
+
+	if(loc == $location[none])
+	{
+		return true;
+	}
+
+	if(!have_equipped($item[Kramco Sausage-o-Matic&trade;]))
+	{
+		if(item_amount($item[Kramco Sausage-o-Matic&trade;]) == 0)
+		{
+			return false;
+		}
+		equip($item[Kramco Sausage-o-Matic&trade;]);
+	}
+	return slAdv(1, loc, option);
+}
+
 boolean pirateRealmAvailable()
 {
 	if(!is_unrestricted($item[PirateRealm membership packet]))


### PR DESCRIPTION
Also add shiny ring to accessory equips (below batskin belt as it has the same enchantment) and Whatsian Ionic Pliers to off-hand equips for Ed (because MP regen is a must as Ed).

Closes #160 

This requires testing before it is merged. I have tested the logic in isolation on my own account but not as part of `sl_ascend` itself as the account I test `sl_ascend` on doesn't have any IotMs.

P.S. cue the deluge of issue reports along the lines of 
> it's not equipping my Sausage Grinder??????