### PR TITLE
Various small tweaks and fixes

### DIFF
--- a/BUILD/equipment/acc.dat
+++ b/BUILD/equipment/acc.dat
@@ -30,7 +30,6 @@ Sphygmayomanometer
 Ring Of The Skeleton Lord
 Gold Detective Badge
 Silver Detective Badge
-Ghost of a Necklace
 Bronze Detective Badge
 Badge Of Authority
 Xiblaxian Holo-Wrist-Puter
@@ -50,6 +49,10 @@ Jangly Bracelet
 Jolly Roger Charrrm Bracelet
 Grumpy Old Man Charrrm Bracelet
 Bonerdagon Necklace
+Ghost of a Necklace
+Blackberry Galoshes
+badass belt
+Talisman o' Namsilat
 Batskin Belt
 shiny ring
 Garish Pinky Ring

--- a/BUILD/equipment/back.dat
+++ b/BUILD/equipment/back.dat
@@ -7,11 +7,11 @@ Camp Scout Backpack
 Buddy Bjorn
 Vampyric Cloake
 Polyester Parachute
-Makeshift Cape
 Sea Shawl
 Misty Robe
 Misty Cape
 Misty Cloak
+Makeshift Cape
 Frozen Turtle Shell
 Giant Gym Membership Card
 Fiberglass Frock

--- a/BUILD/equipment/off-hand.dat
+++ b/BUILD/equipment/off-hand.dat
@@ -22,6 +22,7 @@ Ox-head Shield
 Latte Lovers Member's Mug
 KoL Con 13 Snowglobe
 astral shield
+astral statuette
 Keg Shield
 Wicker Shield
 Sawblade Shield
@@ -29,7 +30,9 @@ Yorick
 Red X Shield
 Party Crasher
 Spiked Femur
+little black book	class:Ed
 Whatsian Ionic Pliers	class:Ed
+giant penguin keychain
 Hot Plate
 Oversized Pizza Cutter
 Cardboard Wakizashi

--- a/BUILD/equipment/pants.dat
+++ b/BUILD/equipment/pants.dat
@@ -24,6 +24,7 @@ Leotarrrd
 Demonskin Trousers
 Ninja Hot Pants
 Antique Greaves
+miner's pants
 Filthy Corduroys
 Psychic's Pslacks
 Knob Goblin Uberpants

--- a/BUILD/equipment/weapon.dat
+++ b/BUILD/equipment/weapon.dat
@@ -74,6 +74,7 @@ world's smallest violin	mainstat:Moxie
 Frigid Derringer	mainstat:Moxie
 witty rapier	mainstat:Mysticality
 Chopsticks	mainstat:Mysticality
+giant artisanal rice peeler	mainstat:Mysticality
 Oversized Pizza Cutter	mainstat:Mysticality
 Eggbeater	mainstat:Mysticality
 Corn Holder	mainstat:Mysticality

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -43,36 +43,39 @@ acc	27	Sphygmayomanometer
 acc	28	Ring Of The Skeleton Lord
 acc	29	Gold Detective Badge
 acc	30	Silver Detective Badge
-acc	31	Ghost of a Necklace
-acc	32	Bronze Detective Badge
-acc	33	Badge Of Authority
-acc	34	Xiblaxian Holo-Wrist-Puter
-acc	35	Mr. Accessory Jr.
-acc	36	Iron Beta of Industry
-acc	37	LOV Earrings
-acc	38	wax hand
-acc	39	Perfume-Soaked Bandana
-acc	40	Wicker Kickers
-acc	41	Compression Stocking
-acc	42	Glow-In-The-Dark Necklace
-acc	43	Time-Twitching Toolbelt
-acc	44	Mr. Accessory
-acc	45	Pirate Fledges
-acc	46	Plastic Detective Badge
-acc	47	Jangly Bracelet
-acc	48	Jolly Roger Charrrm Bracelet
-acc	49	Grumpy Old Man Charrrm Bracelet
-acc	50	Bonerdagon Necklace
-acc	51	Batskin Belt
-acc	52	shiny ring
-acc	53	Garish Pinky Ring
-acc	54	Ring Of Telling Skeletons What To Do
-acc	55	Imp Unity Ring
-acc	56	Infernal Insoles
-acc	57	Glowing Red Eye
-acc	58	Stuffed Shoulder Parrot
-acc	59	Vampire Collar
-acc	60	Jaunty Feather
+acc	31	Bronze Detective Badge
+acc	32	Badge Of Authority
+acc	33	Xiblaxian Holo-Wrist-Puter
+acc	34	Mr. Accessory Jr.
+acc	35	Iron Beta of Industry
+acc	36	LOV Earrings
+acc	37	wax hand
+acc	38	Perfume-Soaked Bandana
+acc	39	Wicker Kickers
+acc	40	Compression Stocking
+acc	41	Glow-In-The-Dark Necklace
+acc	42	Time-Twitching Toolbelt
+acc	43	Mr. Accessory
+acc	44	Pirate Fledges
+acc	45	Plastic Detective Badge
+acc	46	Jangly Bracelet
+acc	47	Jolly Roger Charrrm Bracelet
+acc	48	Grumpy Old Man Charrrm Bracelet
+acc	49	Bonerdagon Necklace
+acc	50	Ghost of a Necklace
+acc	51	Blackberry Galoshes
+acc	52	badass belt
+acc	53	Talisman o' Namsilat
+acc	54	Batskin Belt
+acc	55	shiny ring
+acc	56	Garish Pinky Ring
+acc	57	Ring Of Telling Skeletons What To Do
+acc	58	Imp Unity Ring
+acc	59	Infernal Insoles
+acc	60	Glowing Red Eye
+acc	61	Stuffed Shoulder Parrot
+acc	62	Vampire Collar
+acc	63	Jaunty Feather
 
 # Back items
 back	0	Protonic Accelerator Pack	expectghostreport:true
@@ -83,11 +86,11 @@ back	4	Camp Scout Backpack
 back	5	Buddy Bjorn
 back	6	Vampyric Cloake
 back	7	Polyester Parachute
-back	8	Makeshift Cape
-back	9	Sea Shawl
-back	10	Misty Robe
-back	11	Misty Cape
-back	12	Misty Cloak
+back	8	Sea Shawl
+back	9	Misty Robe
+back	10	Misty Cape
+back	11	Misty Cloak
+back	12	Makeshift Cape
 back	13	Frozen Turtle Shell
 back	14	Giant Gym Membership Card
 back	15	Fiberglass Frock
@@ -238,21 +241,24 @@ off-hand	19	Ox-head Shield
 off-hand	20	Latte Lovers Member's Mug
 off-hand	21	KoL Con 13 Snowglobe
 off-hand	22	astral shield
-off-hand	23	Keg Shield
-off-hand	24	Wicker Shield
-off-hand	25	Sawblade Shield
-off-hand	26	Yorick
-off-hand	27	Red X Shield
-off-hand	28	Party Crasher
-off-hand	29	Spiked Femur
-off-hand	30	Whatsian Ionic Pliers	class:Ed
-off-hand	31	Hot Plate
-off-hand	32	Oversized Pizza Cutter
-off-hand	33	Cardboard Wakizashi
-off-hand	34	Pitchfork
-off-hand	35	Sabre Teeth
-off-hand	36	Knob Goblin Scimitar
-off-hand	37	Turtle Totem
+off-hand	23	astral statuette
+off-hand	24	Keg Shield
+off-hand	25	Wicker Shield
+off-hand	26	Sawblade Shield
+off-hand	27	Yorick
+off-hand	28	Red X Shield
+off-hand	29	Party Crasher
+off-hand	30	Spiked Femur
+off-hand	31	little black book	class:Ed
+off-hand	32	Whatsian Ionic Pliers	class:Ed
+off-hand	33	giant penguin keychain
+off-hand	34	Hot Plate
+off-hand	35	Oversized Pizza Cutter
+off-hand	36	Cardboard Wakizashi
+off-hand	37	Pitchfork
+off-hand	38	Sabre Teeth
+off-hand	39	Knob Goblin Scimitar
+off-hand	40	Turtle Totem
 
 # Good ol' pants
 pants	0	Pantsgiving
@@ -280,24 +286,25 @@ pants	21	Leotarrrd
 pants	22	Demonskin Trousers
 pants	23	Ninja Hot Pants
 pants	24	Antique Greaves
-pants	25	Filthy Corduroys
-pants	26	Psychic's Pslacks
-pants	27	Knob Goblin Uberpants
-pants	28	Alpha-Mail Pants
-pants	29	Bloody Clown Pants
-pants	30	Troutpiece
-pants	31	Paper-Plate-Mail Pants
-pants	32	Hep Waders
-pants	33	Genie's Pants
-pants	34	Union Scalemail Pants
-pants	35	Stylish Swimsuit
-pants	36	Chain-Mail Monokini
-pants	37	Pants Of The Slug Lord
-pants	38	Knob Goblin Pants
-pants	39	three-legged pants
-pants	40	Knob Goblin Harem Pants
-pants	41	Studded Leather Boxer Shorts
-pants	42	Old Sweatpants
+pants	25	miner's pants
+pants	26	Filthy Corduroys
+pants	27	Psychic's Pslacks
+pants	28	Knob Goblin Uberpants
+pants	29	Alpha-Mail Pants
+pants	30	Bloody Clown Pants
+pants	31	Troutpiece
+pants	32	Paper-Plate-Mail Pants
+pants	33	Hep Waders
+pants	34	Genie's Pants
+pants	35	Union Scalemail Pants
+pants	36	Stylish Swimsuit
+pants	37	Chain-Mail Monokini
+pants	38	Pants Of The Slug Lord
+pants	39	Knob Goblin Pants
+pants	40	three-legged pants
+pants	41	Knob Goblin Harem Pants
+pants	42	Studded Leather Boxer Shorts
+pants	43	Old Sweatpants
 
 # Shirts
 shirt	0	LOV Eardigan	mainstat:Muscle
@@ -413,46 +420,47 @@ weapon	56	world's smallest violin	mainstat:Moxie
 weapon	57	Frigid Derringer	mainstat:Moxie
 weapon	58	witty rapier	mainstat:Mysticality
 weapon	59	Chopsticks	mainstat:Mysticality
-weapon	60	Oversized Pizza Cutter	mainstat:Mysticality
-weapon	61	Eggbeater	mainstat:Mysticality
-weapon	62	Corn Holder	mainstat:Mysticality
-weapon	63	Dishrag	mainstat:Mysticality
+weapon	60	giant artisanal rice peeler	mainstat:Mysticality
+weapon	61	Oversized Pizza Cutter	mainstat:Mysticality
+weapon	62	Eggbeater	mainstat:Mysticality
+weapon	63	Corn Holder	mainstat:Mysticality
+weapon	64	Dishrag	mainstat:Mysticality
 # Good knives
-weapon	64	black blade	mainstat:Moxie;skill:Tricky Knifework
-weapon	65	batblade	mainstat:Moxie;skill:Tricky Knifework
-weapon	66	soap knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	67	Saturday Night Special	mainstat:Moxie
+weapon	65	black blade	mainstat:Moxie;skill:Tricky Knifework
+weapon	66	batblade	mainstat:Moxie;skill:Tricky Knifework
+weapon	67	soap knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	68	Saturday Night Special	mainstat:Moxie
 # Knives that are fine
-weapon	68	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
-weapon	69	candy knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	70	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
-weapon	71	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
-weapon	72	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
+weapon	69	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
+weapon	70	candy knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	71	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
+weapon	72	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
+weapon	73	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
 # This stuff is definitely better than garbage
-weapon	73	finger cymbals	mainstat:Moxie
+weapon	74	finger cymbals	mainstat:Moxie
 # The worst knife, but it's still a knife
-weapon	74	boot knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	75	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	75	boot knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	76	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
 # It's not good, but at least it's a ranged weapon that takes one hand
-weapon	76	disco ball	mainstat:Moxie
-weapon	77	stolen accordion	class:Accordion Thief
+weapon	77	disco ball	mainstat:Moxie
+weapon	78	stolen accordion	class:Accordion Thief
 # Some melee weapons
-weapon	78	Rusty Piece Of Rebar
-weapon	79	Octopus's Spade
-weapon	80	Oversized Pipe
-weapon	81	Ghast Iron Cleaver
-weapon	82	Short-Handled Mop
-weapon	83	Spectral Axe
-weapon	84	Antique Machete
-weapon	85	red-hot sausage fork
+weapon	79	Rusty Piece Of Rebar
+weapon	80	Octopus's Spade
+weapon	81	Oversized Pipe
+weapon	82	Ghast Iron Cleaver
+weapon	83	Short-Handled Mop
+weapon	84	Spectral Axe
+weapon	85	Antique Machete
+weapon	86	red-hot sausage fork
 # Almost absolute garbage
-weapon	86	Skeleton Bone
-weapon	87	Corn Holder
-weapon	88	Knob Goblin Scimitar
-weapon	89	Knob Goblin Tongs
+weapon	87	Skeleton Bone
+weapon	88	Corn Holder
+weapon	89	Knob Goblin Scimitar
+weapon	90	Knob Goblin Tongs
 # Absolute garbage, but better than nothing, probably?
-weapon	90	Turtle Totem	class:Turtle Tamer
-weapon	91	Saucepan	class:Sauceror
-weapon	92	Pasta Spoon	class:Pastamancer
+weapon	91	Turtle Totem	class:Turtle Tamer
+weapon	92	Saucepan	class:Sauceror
+weapon	93	Pasta Spoon	class:Pastamancer
 # I probably missed some stuff from the old weapon handling but c'est la vie
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -9398,6 +9398,7 @@ boolean L7_crypt()
 		{
 			set_property("sl_crypt", "finished");
 			use(1, $item[chest of the bonerdagon]);
+			sl_badassBelt(); // mafia doesn't make this any more even if autoCraft = true for some random reason so lets do it manually.
 		}
 		else if(get_property("questL07Cyrptic") == "finished")
 		{
@@ -10212,6 +10213,7 @@ boolean L4_batCave()
 		if(item_amount($item[Batskin Belt]) != batskinBelt)
 		{
 			set_property("sl_bat", "finished");
+			sl_badassBelt(); // mafia doesn't make this any more even if autoCraft = true for some random reason so lets do it manually.
 		}
 		return true;
 	}
@@ -11272,7 +11274,7 @@ boolean L2_spookySapling()
 
 boolean L2_mosquito()
 {
-	if(item_amount($item[mosquito larva]) > 0)
+	if(get_property("sl_mosquito") != "finished" && item_amount($item[mosquito larva]) > 0)
 	{
 		council();
 		set_property("sl_mosquito", "finished");
@@ -14371,23 +14373,20 @@ boolean doTasks()
 		useCocoon();
 	}
 
-	if(my_ascensions() > 100)
+	if(my_daycount() == 1)
 	{
-		if(my_daycount() == 1)
-		{
-			if((my_adventures() < 10) && (my_level() >= 7) && (my_hp() > 0))
-			{
-				fightScienceTentacle();
-				if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))
-				{
-					evokeEldritchHorror();
-				}
-			}
-		}
-		else if((my_level() >= 9) && (my_hp() > 0))
+		if((my_adventures() < 10) && (my_level() >= 7) && (my_hp() > 0))
 		{
 			fightScienceTentacle();
+			if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))
+			{
+				evokeEldritchHorror();
+			}
 		}
+	}
+	else if((my_level() >= 9) && (my_hp() > 0))
+	{
+		fightScienceTentacle();
 	}
 
 	if(LX_catBurglarHeist())			return true;

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -881,6 +881,8 @@ boolean sl_check_conditions(string conds); //Defined in sl_ascend/sl_util.ash
 
 boolean [monster] sl_getMonsters(string category); //Defined in sl_ascend/sl_util.ash
 
+boolean sl_badassBelt(); //Defined in sl_ascend/sl_util.ash
+
 //Dump from accessory scripts.
 void handlePreAdventure();									//Defined in presool.ash
 void handlePreAdventure(location place);					//Defined in presool.ash

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -151,6 +151,7 @@ boolean sl_debug_print(string s, string color);
 boolean sl_debug_print(string s);
 boolean sl_can_equip(item it);
 boolean sl_can_equip(item it, slot s);
+boolean sl_badassBelt();
 
 
 // Private Prototypes
@@ -5375,4 +5376,35 @@ int total_items(boolean [item] items)
 		total += item_amount(it);
 	}
 	return total;
+}
+
+boolean sl_badassBelt()
+{
+	if ((item_amount($item[Batskin Belt]) > 0 || equipped_amount($item[Batskin Belt]) > 0) && (item_amount($item[Skull of the Bonerdagon]) > 0 || equipped_amount($item[Skull of the Bonerdagon]) > 0))
+	{
+		if (have_equipped($item[Skull of the Bonerdagon]))
+		{
+			equip($slot[off-hand], $item[none]);
+		}
+		if (have_equipped($item[Batskin Belt]))
+		{
+			if (equipped_item($slot[acc1]) == $item[Batskin Belt])
+			{
+				equip($slot[acc1], $item[none]);
+			}
+			else if (equipped_item($slot[acc2]) == $item[Batskin Belt])
+			{
+				equip($slot[acc2], $item[none]);
+			}
+			else if (equipped_item($slot[acc3]) == $item[Batskin Belt])
+			{
+				equip($slot[acc3], $item[none]);
+			}
+		}
+		return create(1, $item[Badass Belt]);
+	}
+	else
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
- Make badass belt manually as mafia no longer does
- Fix council text & "Visiting Bart Ender" spam after getting mosquito
- Allow everyone regardless of number of ascensions to fight tentacles
- Add giant artisanal rice peeler to myst class weapon equips
- Add miner's pants to pant equips
- Add astral statuette and giant penguin keychain to off-hand equips
- Add little black book to off-hand equips for Ed
- Move Makeshift Cape down in back equips so it's lower than L9 reward
- Move Ghost of a Necklace in acc equips below Bonerdagon Necklace
- Add Blackberry Galoshes, Badass Belt and Talisman o' Namsilat to acc equips