### PR TITLE
Some small fixes

### DIFF
--- a/BUILD/equipment/off-hand.dat
+++ b/BUILD/equipment/off-hand.dat
@@ -30,9 +30,12 @@ Yorick
 Red X Shield
 Party Crasher
 Spiked Femur
+red book	class:Ed
 little black book	class:Ed
 Whatsian Ionic Pliers	class:Ed
 giant penguin keychain
+snake shield
+snarling wolf shield
 Hot Plate
 Oversized Pizza Cutter
 Cardboard Wakizashi

--- a/BUILD/equipment/pants.dat
+++ b/BUILD/equipment/pants.dat
@@ -1,6 +1,7 @@
 # Good ol' pants
 Pantsgiving
 Astral Shorts
+Astral Trousers
 discarded swimming trunks	mainstat:Muscle
 Bankruptcy Barrel
 Troutsers
@@ -16,6 +17,7 @@ Bloodied Surgical Dungarees
 Pygmy Briefs
 Furry Pants
 Oil Slacks
+Whoompa Fur Pants
 Snowboarder Pants
 Troutpiece
 Burnt Snowpants

--- a/BUILD/equipment/weapon.dat
+++ b/BUILD/equipment/weapon.dat
@@ -76,6 +76,7 @@ witty rapier	mainstat:Mysticality
 Chopsticks	mainstat:Mysticality
 giant artisanal rice peeler	mainstat:Mysticality
 Oversized Pizza Cutter	mainstat:Mysticality
+Filthy Pestle	mainstat:Mysticality
 Eggbeater	mainstat:Mysticality
 Corn Holder	mainstat:Mysticality
 Dishrag	mainstat:Mysticality

--- a/RELEASE/data/sl_ascend_equipment.txt
+++ b/RELEASE/data/sl_ascend_equipment.txt
@@ -249,62 +249,67 @@ off-hand	27	Yorick
 off-hand	28	Red X Shield
 off-hand	29	Party Crasher
 off-hand	30	Spiked Femur
-off-hand	31	little black book	class:Ed
-off-hand	32	Whatsian Ionic Pliers	class:Ed
-off-hand	33	giant penguin keychain
-off-hand	34	Hot Plate
-off-hand	35	Oversized Pizza Cutter
-off-hand	36	Cardboard Wakizashi
-off-hand	37	Pitchfork
-off-hand	38	Sabre Teeth
-off-hand	39	Knob Goblin Scimitar
-off-hand	40	Turtle Totem
+off-hand	31	red book	class:Ed
+off-hand	32	little black book	class:Ed
+off-hand	33	Whatsian Ionic Pliers	class:Ed
+off-hand	34	giant penguin keychain
+off-hand	35	snake shield
+off-hand	36	snarling wolf shield
+off-hand	37	Hot Plate
+off-hand	38	Oversized Pizza Cutter
+off-hand	39	Cardboard Wakizashi
+off-hand	40	Pitchfork
+off-hand	41	Sabre Teeth
+off-hand	42	Knob Goblin Scimitar
+off-hand	43	Turtle Totem
 
 # Good ol' pants
 pants	0	Pantsgiving
 pants	1	Astral Shorts
-pants	2	discarded swimming trunks	mainstat:Muscle
-pants	3	Bankruptcy Barrel
-pants	4	Troutsers
-pants	5	Pantogram Pants
-pants	6	Greatest American Pants
-pants	7	Distressed Denim Pants
-pants	8	Xiblaxian Stealth Trousers
-pants	9	Troll Britches
-pants	10	Vicar's Tutu
-pants	11	Stainless Steel Slacks
-pants	12	Spangly Mariachi Pants
-pants	13	Bloodied Surgical Dungarees
-pants	14	Pygmy Briefs
-pants	15	Furry Pants
-pants	16	Oil Slacks
-pants	17	Snowboarder Pants
-pants	18	Troutpiece
-pants	19	Burnt Snowpants
-pants	20	Swashbuckling Pants
-pants	21	Leotarrrd
-pants	22	Demonskin Trousers
-pants	23	Ninja Hot Pants
-pants	24	Antique Greaves
-pants	25	miner's pants
-pants	26	Filthy Corduroys
-pants	27	Psychic's Pslacks
-pants	28	Knob Goblin Uberpants
-pants	29	Alpha-Mail Pants
-pants	30	Bloody Clown Pants
-pants	31	Troutpiece
-pants	32	Paper-Plate-Mail Pants
-pants	33	Hep Waders
-pants	34	Genie's Pants
-pants	35	Union Scalemail Pants
-pants	36	Stylish Swimsuit
-pants	37	Chain-Mail Monokini
-pants	38	Pants Of The Slug Lord
-pants	39	Knob Goblin Pants
-pants	40	three-legged pants
-pants	41	Knob Goblin Harem Pants
-pants	42	Studded Leather Boxer Shorts
-pants	43	Old Sweatpants
+pants	2	Astral Trousers
+pants	3	discarded swimming trunks	mainstat:Muscle
+pants	4	Bankruptcy Barrel
+pants	5	Troutsers
+pants	6	Pantogram Pants
+pants	7	Greatest American Pants
+pants	8	Distressed Denim Pants
+pants	9	Xiblaxian Stealth Trousers
+pants	10	Troll Britches
+pants	11	Vicar's Tutu
+pants	12	Stainless Steel Slacks
+pants	13	Spangly Mariachi Pants
+pants	14	Bloodied Surgical Dungarees
+pants	15	Pygmy Briefs
+pants	16	Furry Pants
+pants	17	Oil Slacks
+pants	18	Whoompa Fur Pants
+pants	19	Snowboarder Pants
+pants	20	Troutpiece
+pants	21	Burnt Snowpants
+pants	22	Swashbuckling Pants
+pants	23	Leotarrrd
+pants	24	Demonskin Trousers
+pants	25	Ninja Hot Pants
+pants	26	Antique Greaves
+pants	27	miner's pants
+pants	28	Filthy Corduroys
+pants	29	Psychic's Pslacks
+pants	30	Knob Goblin Uberpants
+pants	31	Alpha-Mail Pants
+pants	32	Bloody Clown Pants
+pants	33	Troutpiece
+pants	34	Paper-Plate-Mail Pants
+pants	35	Hep Waders
+pants	36	Genie's Pants
+pants	37	Union Scalemail Pants
+pants	38	Stylish Swimsuit
+pants	39	Chain-Mail Monokini
+pants	40	Pants Of The Slug Lord
+pants	41	Knob Goblin Pants
+pants	42	three-legged pants
+pants	43	Knob Goblin Harem Pants
+pants	44	Studded Leather Boxer Shorts
+pants	45	Old Sweatpants
 
 # Shirts
 shirt	0	LOV Eardigan	mainstat:Muscle
@@ -422,45 +427,46 @@ weapon	58	witty rapier	mainstat:Mysticality
 weapon	59	Chopsticks	mainstat:Mysticality
 weapon	60	giant artisanal rice peeler	mainstat:Mysticality
 weapon	61	Oversized Pizza Cutter	mainstat:Mysticality
-weapon	62	Eggbeater	mainstat:Mysticality
-weapon	63	Corn Holder	mainstat:Mysticality
-weapon	64	Dishrag	mainstat:Mysticality
+weapon	62	Filthy Pestle	mainstat:Mysticality
+weapon	63	Eggbeater	mainstat:Mysticality
+weapon	64	Corn Holder	mainstat:Mysticality
+weapon	65	Dishrag	mainstat:Mysticality
 # Good knives
-weapon	65	black blade	mainstat:Moxie;skill:Tricky Knifework
-weapon	66	batblade	mainstat:Moxie;skill:Tricky Knifework
-weapon	67	soap knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	68	Saturday Night Special	mainstat:Moxie
+weapon	66	black blade	mainstat:Moxie;skill:Tricky Knifework
+weapon	67	batblade	mainstat:Moxie;skill:Tricky Knifework
+weapon	68	soap knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	69	Saturday Night Special	mainstat:Moxie
 # Knives that are fine
-weapon	69	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
-weapon	70	candy knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	71	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
-weapon	72	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
-weapon	73	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
+weapon	70	half-size scalpel	mainstat:Moxie;skill:Tricky Knifework
+weapon	71	candy knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	72	sharpened spoon	mainstat:Moxie;skill:Tricky Knifework
+weapon	73	sabre teeth	mainstat:Moxie;skill:Tricky Knifework
+weapon	74	broken beer bottle	mainstat:Moxie;skill:Tricky Knifework
 # This stuff is definitely better than garbage
-weapon	74	finger cymbals	mainstat:Moxie
+weapon	75	finger cymbals	mainstat:Moxie
 # The worst knife, but it's still a knife
-weapon	75	boot knife	mainstat:Moxie;skill:Tricky Knifework
-weapon	76	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	76	boot knife	mainstat:Moxie;skill:Tricky Knifework
+weapon	77	asparagus knife	mainstat:Moxie;skill:Tricky Knifework
 # It's not good, but at least it's a ranged weapon that takes one hand
-weapon	77	disco ball	mainstat:Moxie
-weapon	78	stolen accordion	class:Accordion Thief
+weapon	78	disco ball	mainstat:Moxie
+weapon	79	stolen accordion	class:Accordion Thief
 # Some melee weapons
-weapon	79	Rusty Piece Of Rebar
-weapon	80	Octopus's Spade
-weapon	81	Oversized Pipe
-weapon	82	Ghast Iron Cleaver
-weapon	83	Short-Handled Mop
-weapon	84	Spectral Axe
-weapon	85	Antique Machete
-weapon	86	red-hot sausage fork
+weapon	80	Rusty Piece Of Rebar
+weapon	81	Octopus's Spade
+weapon	82	Oversized Pipe
+weapon	83	Ghast Iron Cleaver
+weapon	84	Short-Handled Mop
+weapon	85	Spectral Axe
+weapon	86	Antique Machete
+weapon	87	red-hot sausage fork
 # Almost absolute garbage
-weapon	87	Skeleton Bone
-weapon	88	Corn Holder
-weapon	89	Knob Goblin Scimitar
-weapon	90	Knob Goblin Tongs
+weapon	88	Skeleton Bone
+weapon	89	Corn Holder
+weapon	90	Knob Goblin Scimitar
+weapon	91	Knob Goblin Tongs
 # Absolute garbage, but better than nothing, probably?
-weapon	91	Turtle Totem	class:Turtle Tamer
-weapon	92	Saucepan	class:Sauceror
-weapon	93	Pasta Spoon	class:Pastamancer
+weapon	92	Turtle Totem	class:Turtle Tamer
+weapon	93	Saucepan	class:Sauceror
+weapon	94	Pasta Spoon	class:Pastamancer
 # I probably missed some stuff from the old weapon handling but c'est la vie
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -5363,7 +5363,7 @@ boolean LX_attemptFlyering()
 
 boolean powerLevelAdjustment()
 {
-	if(get_property("sl_powerLevelLastLevel").to_int() != my_level())
+	if(get_property("sl_powerLevelLastLevel").to_int() != my_level() && get_property("sl_powerLevelAdvCount").to_int() > 0)
 	{
 		set_property("sl_powerLevelLastLevel", my_level());
 		set_property("sl_powerLevelAdvCount", 0);
@@ -11329,11 +11329,12 @@ boolean LX_handleSpookyravenFirstFloor()
 	}
 	if(delayKitchen)
 	{
-		if((elemental_resist($element[hot]) < 9) || (elemental_resist($element[stench]) < 9))
+		if(elemental_resist($element[hot]) < 9 || elemental_resist($element[stench]) < 9)
 		{
 			if(my_class() == $class[Ed])
 			{
-				delayKitchen = have_skill($skill[Even More Elemental Wards]);
+				// this should be false if we have the 3rd resist upgrade (max available for Ed) and true if we don't!
+				delayKitchen = !have_skill($skill[Even More Elemental Wards]); 
 			}
 		}
 		else
@@ -13000,9 +13001,18 @@ boolean L11_ronCopperhead()
 
 	if((internalQuestStatus("questL11Ron") == 2) || (internalQuestStatus("questL11Ron") == 3) || (internalQuestStatus("questL11Ron") == 4))
 	{
-		if((item_amount($item[Red Zeppelin Ticket]) == 0) && (my_meat() > npc_price($item[Red Zeppelin Ticket])))
+		if (item_amount($item[Red Zeppelin Ticket]) < 1)
 		{
-			buy(1, $item[Red Zeppelin Ticket]);
+			// use the priceless diamond since we go to the effort of trying to get one in the Copperhead Club
+			// and it saves us 4.5k meat.
+			if (item_amount($item[priceless diamond]) > 0)
+			{
+				buy($coinmaster[The Black Market], 1, $item[Red Zeppelin Ticket]);
+			}
+			else if (my_meat() > npc_price($item[Red Zeppelin Ticket]))
+			{
+				buy(1, $item[Red Zeppelin Ticket]);
+			}
 		}
 		// For Glark Cables. OPTIMAL!
 		bat_formBats();
@@ -13081,6 +13091,12 @@ boolean L11_shenCopperhead()
 	if((internalQuestStatus("questL11Shen") == 1) || (internalQuestStatus("questL11Shen") == 3) || (internalQuestStatus("questL11Shen") == 5))
 	{
 		item it = to_item(get_property("shenQuestItem"));
+		if (it == $item[none] && my_class() == $class[Ed])
+		{
+			// temp workaround until mafia bug is fixed - https://kolmafia.us/showthread.php?23742
+			cli_execute("refresh quests");
+			it = to_item(get_property("shenQuestItem"));
+		}
 		location goal = $location[none];
 		switch(it)
 		{

--- a/RELEASE/scripts/sl_ascend/sl_adventure.ash
+++ b/RELEASE/scripts/sl_ascend/sl_adventure.ash
@@ -11,6 +11,7 @@ boolean slAdv(int num, location loc, string option)
 {
 	set_property("sl_combatHandler", "");
 	set_property("sl_diag_round", 0);
+	set_property("nextAdventure", loc);
 	if(option == "")
 	{
 		option = "sl_combatHandler";


### PR DESCRIPTION
`powerLevelAdjustment()` should only update `sl_powerLevelLastLevel` when you've actually spent adventures powerlevelling otherwise it's always being set to `my_level()` after you level up which makes it useless for anything.
Invert result of test for Even More Elemental Wards when figuring out whether to delay the haunted kitchen or not (as Ed).
Use the priceless diamond if we have one rather than meat to buy the Red Zeppelin ticket.
Add workaround for KoL/KoLMafia issue -> https://kolmafia.us/showthread.php?23742 so Ed knows what item Shen is asking for the first time you speak to him. (really closes #7)
Add some more stuff to the equip data files.

Edit: added another change. I noticed that `slAdv` isn't setting `nextAdventure` but `slAdvBypass` does. This is to fix things like the following:

```
use 1 A-Boo clue
Preference sl_aboopending changed from 0 to 687
Visiting The Servants' Quarters
Putting your Priest to work
Current servant: Neamut, the Priest (lvl. 20, 418 xp)
Visiting The Servants' Quarters
Putting your Cat to work
Current servant: Makasebheet, the Cat (lvl. 17, 319 xp)
> Starting preadventure script...

equip acc3 Talisman o' Namsilat
> Pre Adventure at Inside the Palindome done, beep.
Preference sl_disableAdventureHandling changed from false to true
Preference sl_edCombatHandler changed from (lashofthecobra) to 
> Starting Ed Battle at A-Boo Peak
Preference nextAdventure changed from Inside the Palindome to A-Boo Peak
> Preadventure skipped by standard adventure handler.
Preference lastAdventure changed from Inside the Palindome to A-Boo Peak

[688] A-Boo Peak
Preference lastEncounter changed from Drab Bard to The Horror...
Encounter: The Horror...
Took choice 611/1: 1 spooky damage, 1 cold damage
choice.php?whichchoice=611&option=1&pwd
Encounter: The Horror...
Preference booPeakProgress changed from 90 to 88
You lose 1 hit point
You lose 1 hit point
Took choice 611/1: 1 spooky damage, 1 cold damage
choice.php?whichchoice=611&option=1&pwd
Encounter: The Horror...
Preference booPeakProgress changed from 88 to 84
You lose 1 hit point
You lose 1 hit point
Took choice 611/1: 8 spooky damage, 10 cold damage
choice.php?whichchoice=611&option=1&pwd
Encounter: The Horror...
Preference booPeakProgress changed from 84 to 78
You lose 7 hit points
You lose 9 hit points
Took choice 611/1: 19 spooky damage, 24 cold damage
choice.php?whichchoice=611&option=1&pwd
Encounter: The Horror...
Preference booPeakProgress changed from 78 to 70
You lose 19 hit points
You lose 23 hit points
Took choice 611/1: 37 spooky damage, 48 cold damage
choice.php?whichchoice=611&option=1&pwd
Preference booPeakProgress changed from 70 to 68
You lose 37 hit points
You lose 47 hit points
> Postadventure skipped by standard adventure handler.
Preference sl_aboopending changed from 687 to 0
```

That log is from previous run but I saw it doing the same thing in the run I'm testing currently. The Talisman o' Namsilat replacing the ghost of a necklace wasn't enough to cause an early failure in The Horror this time however (and I'd been meaning to investigate this).