### PR TITLE
Asdon and ML optimization, Tavern Grouping, and TCRS verification

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12579,13 +12579,6 @@ boolean L9_oilPeak()
 		buffMaintain($effect[Ceaseless Snarling], 0, 1, 1);
 	}
 
-	// Never puddle jump, but don't deliberately go crowd-punching the Cartels
-	if(((monster_level_adjustment() >= 25) && (monster_level_adjustment() <= 49)) || (monster_level_adjustment() <= 11))
-	{
-		string to_max = "ML";
-		maximize(to_max, false);
-	}
-
 	// Maximize Asdon usage
 	if(((monster_level_adjustment() >= 75) && (monster_level_adjustment() <= 99)) || ((monster_level_adjustment() >= 25) && (monster_level_adjustment() <= 49)) || (monster_level_adjustment() <= 11))
 	{
@@ -12612,9 +12605,10 @@ boolean L9_oilPeak()
 		}
 	}
 
+	addToMaximize("1000ml 100max");
+
 	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
 
-	addToMaximize("1000ml 100max");
 	slAdv(1, $location[Oil Peak]);
 	if(get_property("lastAdventure") == "Unimpressed with Pressure")
 	{
@@ -13952,17 +13946,22 @@ boolean sl_tavern()
 			providePlusNonCombat(25);
 		}
 
-		if(my_path() != "Actually Ed the Undying")
+		if((my_path() != "Actually Ed the Undying") && (monster_level_adjustment() <= 299))
 		{
 			// Maximize ML First by using equipment
-			if(monster_level_adjustment() <= 150)
+			if(useMaximizeToEquip())
 			{
+				addToMaximize("1000ml 300max");
+			}
+			else
+			{
+
 				string to_max = "ML";
 				maximize(to_max, false);
 			}		
 	
 			// Asdon usage increases Rat King chance by 8.3%
-			if(monster_level_adjustment() <= 150)
+			if(monster_level_adjustment() <= 299)
 			{
 				asdonBuff($effect[Driving Recklessly]);
 			}

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -6983,7 +6983,7 @@ boolean L11_unlockEd()
 	{
 		print("Uh oh, didn\'t do the tavern and we are at the pyramid....", "red");
 		set_property("sl_forceTavern", true);
-		L3_tavern()
+		L3_tavern();
 	}
 
 	print("In the pyramid (W:" + item_amount($item[crumbling wooden wheel]) + ") (R:" + item_amount($item[tomb ratchet]) + ") (U:" + get_property("controlRoomUnlock") + ")", "blue");
@@ -12521,7 +12521,6 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
 
 	if(contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
 	{
@@ -12579,6 +12578,14 @@ boolean L9_oilPeak()
 	{
 		buffMaintain($effect[Ceaseless Snarling], 0, 1, 1);
 	}
+
+	// Never puddle jump, but don't deliberately go crowd-punching the Cartels
+	if(((monster_level_adjustment() >= 25) && (monster_level_adjustment() <= 49)) || (monster_level_adjustment() <= 11))
+	{
+		string to_max = "ML";
+		maximize(to_max, false);
+	}
+
 	// Maximize Asdon usage
 	if(((monster_level_adjustment() >= 75) && (monster_level_adjustment() <= 99)) || ((monster_level_adjustment() >= 25) && (monster_level_adjustment() <= 49)) || (monster_level_adjustment() <= 11))
 	{
@@ -12588,6 +12595,7 @@ boolean L9_oilPeak()
 	{
 		asdonBuff($effect[Driving Wastefully]);
 	}
+
 	if((monster_level_adjustment() < 60))
 	{
 		if (item_amount($item[Dress Pants]) > 0)
@@ -12603,6 +12611,9 @@ boolean L9_oilPeak()
 			}
 		}
 	}
+
+	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
+
 	addToMaximize("1000ml 100max");
 	slAdv(1, $location[Oil Peak]);
 	if(get_property("lastAdventure") == "Unimpressed with Pressure")
@@ -12611,7 +12622,7 @@ boolean L9_oilPeak()
 		// Brute Force grouping with tavern (if not done) to maximize tangles while we have a high ML.
 		print("Checking to see if we should do the tavern while we are running high ML.", "green");
 		set_property("sl_forceTavern", true);
-		L3_tavern()
+		L3_tavern();
 
 	}
 	handleFamiliar("item");

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -2641,7 +2641,7 @@ boolean doBedtime()
 		use(1, $item[resolution: be more adventurous]);
 	}
 
-	if(in_tcrs())
+	if((in_tcrs()) && (freeCrafts() > 0))
 	{
 		print("Using My Free Crafts will have no benefit.", "red");
 		print("Consider manually using your "+freeCrafts()+" free crafts", "red");
@@ -9403,7 +9403,7 @@ boolean LX_hardcoreFoodFarm()
 {
 	if(in_tcrs())
 	{
-		print("Food farming pointless in my path.", "orange");
+		print("Food farming pointless in my path.");
 		return false;
 	}
 	if(!in_hardcore() || !isGuildClass())

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -2644,7 +2644,7 @@ boolean doBedtime()
 	if(in_tcrs())
 	{
 		print("Using My Free Crafts will have no benefit.", "red");
-		print("Consider manually using your "+freeCrafts()+" free crafts"), "red");
+		print("Consider manually using your "+freeCrafts()+" free crafts", "red");
 	}
 	else if((my_daycount() <= 2) && (freeCrafts() > 0))
 	{

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1,6 +1,6 @@
 script "sl_ascend.ash";
 notify soolar the second;
-since r19335; // monster.copyable
+since r19375; // beach comb
 /***
 	Killing is wrong, and bad. There should be a new, stronger word for killing like badwrong or badong. YES, killing is badong. From this moment, I will stand for the opposite of killing, gnodab.
 

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -13952,17 +13952,20 @@ boolean sl_tavern()
 			providePlusNonCombat(25);
 		}
 
-		// Maximize ML First by using equipment
-		if((monster_level_adjustment() <= 150) && (!my_path() == "Actually Ed the Undying"))
+		if(my_path() != "Actually Ed the Undying")
 		{
-			string to_max = "ML";
-			maximize(to_max, false);
-		}		
-
-		// Asdon usage increases Rat King chance by 8.3%
-		if((monster_level_adjustment() <= 150) && (!my_path() == "Actually Ed the Undying"))
-		{
-			asdonBuff($effect[Driving Recklessly]);
+			// Maximize ML First by using equipment
+			if(monster_level_adjustment() <= 150)
+			{
+				string to_max = "ML";
+				maximize(to_max, false);
+			}		
+	
+			// Asdon usage increases Rat King chance by 8.3%
+			if(monster_level_adjustment() <= 150)
+			{
+				asdonBuff($effect[Driving Recklessly]);
+			}
 		}
 
 		tavern = get_property("tavernLayout");


### PR DESCRIPTION
Optimize- Asdon Usage on oil peak
Optimize- Asdon and ML usage in Tavern (except Ed The Undying)
Optimize- Grouped Tavern w/ Oil Peak (for high ML) and Pyramid (for Rat Tails)
BugFix	- Check for TCRS before wasting Bedtime crafting
BugFix	- Check for TCRS before food farming