### PR TITLE
Refactor auto-consumption code, consider Saucemaven, support Chez Snootee

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -6172,6 +6172,33 @@ boolean L11_hiddenCityZones()
 	return false;
 }
 
+boolean L11_wishForBaaBaaBuran()
+{
+	if(!get_property("sl_useWishes").to_boolean() && canGenieCombat())
+	{
+		print("Skipping wishing for Baa'baa'bu'ran because sl_useWishes=false", "red");
+	}
+	if (get_property("sl_useWishes").to_boolean() && canGenieCombat())
+	{
+		print("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
+		handleFamiliar("item");
+		if((numeric_modifier("item drop") >= 100))
+		{
+			if (!makeGenieCombat($monster[Baa\'baa\'bu\'ran]) || item_amount($item[Stone Wool]) == 0)
+			{
+				print("Wishing for stone wool failed.", "red");
+				return false;
+			}
+			return true;
+		}
+		else
+		{
+			print("Never mind, we couldn't get a mere +100% item for the Baa'baa'bu'ran wish.", "red");
+		}
+	}
+	return false;
+}
+
 boolean L11_unlockHiddenCity()
 {
 	if(my_level() < 11)
@@ -6210,26 +6237,7 @@ boolean L11_unlockHiddenCity()
 	{
 		if((item_amount($item[Stone Wool]) == 0) && (have_effect($effect[Stone-Faced]) == 0))
 		{
-			if(!get_property("sl_useWishes").to_boolean() && canGenieCombat())
-			{
-				print("Skipping wishing for Baa'baa'bu'ran because sl_useWishes=false", "red");
-			}
-			if (get_property("sl_useWishes").to_boolean() && canGenieCombat())
-			{
-				print("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
-				handleFamiliar("item");
-				if((numeric_modifier("item drop") >= 100))
-				{
-					if (!makeGenieCombat($monster[Baa\'baa\'bu\'ran]) || item_amount($item[Stone Wool]) == 0)
-					{
-						print("Wishing for stone wool failed.", "red");
-					}
-				}
-				else
-				{
-					print("Never mind, we couldn't get a mere +100% item for the Baa'baa'bu'ran wish.", "red");
-				}
-			}
+			L11_wishForBaaBaaBuran();
 			pullXWhenHaveY($item[Stone Wool], 1, 0);
 		}
 		buffMaintain($effect[Stone-Faced], 0, 1, 1);
@@ -6328,6 +6336,7 @@ boolean L11_nostrilOfTheSerpent()
 	{
 		if((item_amount($item[Stone Wool]) == 0) && (have_effect($effect[Stone-Faced]) == 0))
 		{
+			L11_wishForBaaBaaBuran();
 			pullXWhenHaveY($item[Stone Wool], 1, 0);
 		}
 		buffMaintain($effect[Stone-Faced], 0, 1, 1);

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -2385,7 +2385,7 @@ boolean doBedtime()
 	{
 		if(my_inebriety() <= inebriety_limit())
 		{
-			if(my_class() != $class[Gelatinous Noob])
+			if(my_class() != $class[Gelatinous Noob] && my_familiar() != $familiar[Stooper])
 			{
 				return false;
 			}
@@ -2991,15 +2991,7 @@ boolean doBedtime()
 			print("You have a rain man to cast, please do so before overdrinking and then run me again.", "red");
 			return false;
 		}
-		item best_nightcap = sl_bestNightcap();
-		if(available_amount(best_nightcap) == 0)
-		{
-			print("You can create and drink a " + best_nightcap + " (" + best_nightcap.adventures + " adventures) as your nightcap! Yay!", "blue");
-		}
-		else
-		{
-			print("You can drink a " + best_nightcap + " (" + best_nightcap.adventures + " adventures) as your nightcap! Yay!", "blue");
-		}
+		sl_autoDrinkNightcap(true); // simulate;
 		print("You need to overdrink and then run me again. Beep.", "red");
 		if(have_skill($skill[The Ode to Booze]))
 		{
@@ -14710,18 +14702,6 @@ void sl_begin()
 	{
 		print("You have an auto attack enabled. This may cause issues. We will try anyway.", "blue");
 		wait(10);
-	}
-
-	// Check to see if we're doing Stooper things.
-	use_familiar($familiar[none]);
-	if (my_inebriety() > inebriety_limit() && doBedtime())
-	{
-		if(sl_have_familiar($familiar[Stooper]))
-		{
-			use_familiar($familiar[Stooper]);
-		}
-		print("Done for today (" + my_daycount() + "), beep boop");
-		return;
 	}
 
 	//This also should set our path too.

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -390,10 +390,9 @@ boolean clear_property_if(string setting, string cond);		//Defined in sl_ascend/
 boolean slDrink(int howMany, item toDrink);					//Defined in sl_ascend/sl_cooking.ash
 boolean slEat(int howMany, item toEat);						//Defined in sl_ascend/sl_cooking.ash
 boolean slEat(int howMany, item toEat, boolean silent);		//Defined in sl_ascend/sl_cooking.ash
-boolean sl_knapsackAutoEat(boolean simulate);				//Defined in sl_ascend/sl_cooking.ash
-boolean loadDrinks(item[int] item_backmap, float[int] adv, int[int] inebriety);					//Defined in sl_ascend/sl_cooking.ash
-item sl_bestNightcap();										//Defined in sl_ascend/sl_cooking.ash
-boolean sl_knapsackAutoDrink(boolean simulate);				//Defined in sl_ascend/sl_cooking.ash
+boolean sl_knapsackAutoConsume(string type, boolean simulate);	//Defined in sl_ascend/sl_cooking.ash
+boolean loadConsumables(item[int] item_backmap, int[int] cafe_backmap, float[int] adv, int[int] inebriety);	 //Defined in sl_ascend/sl_cooking.ash
+void sl_autoDrinkNightcap(boolean simulate);				//Defined in sl_ascend/sl_cooking.ash
 boolean sl_autoDrinkOne(boolean simulate);					//Defined in sl_ascend/sl_cooking.ash
 boolean slMaximize(string req, boolean simulate);			//Defined in sl_ascend/sl_util.ash
 boolean slMaximize(string req, int maxPrice, int priceLevel, boolean simulate);//Defined in sl_ascend/sl_util.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -394,6 +394,7 @@ boolean sl_knapsackAutoConsume(string type, boolean simulate);	//Defined in sl_a
 boolean loadConsumables(item[int] item_backmap, int[int] cafe_backmap, float[int] adv, int[int] inebriety);	 //Defined in sl_ascend/sl_cooking.ash
 void sl_autoDrinkNightcap(boolean simulate);				//Defined in sl_ascend/sl_cooking.ash
 boolean sl_autoDrinkOne(boolean simulate);					//Defined in sl_ascend/sl_cooking.ash
+boolean saucemavenApplies(item it);							//Defined in sl_ascend/sl_cooking.ash
 boolean slMaximize(string req, boolean simulate);			//Defined in sl_ascend/sl_util.ash
 boolean slMaximize(string req, int maxPrice, int priceLevel, boolean simulate);//Defined in sl_ascend/sl_util.ash
 aggregate slMaximize(string req, int maxPrice, int priceLevel, boolean simulate, boolean includeEquip);//Defined in sl_ascend/sl_util.ash

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1940,8 +1940,7 @@ boolean sl_knapsackAutoConsume(string type, boolean simulate)
 			}
 			else if (type == "eat")
 			{
-				// TODO: implement slEatCafe
-				// slEatCafe(1, what);
+				slEatCafe(1, what);
 			}
 		}
 		else

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -120,7 +120,7 @@ float expectedAdventuresFrom(item it)
 	float expected = parse();
 	if(sl_have_skill($skill[Saucemaven]) && saucemavenApplies(it))
 	{
-		if (my_class() == $class[Sauceror]) expected += 5;
+		if ($classes[Sauceror, Pastamancer] contains my_class()) expected += 5;
 		else expected += 3;
 	}
 	//if (item_amount($item[black label]) > 0 && $items[bottle of gin, bottle of rum, bottle of tequila, bottle of vodka or bottle of whiskey] contains it)

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -80,6 +80,33 @@ boolean keepOnTruckin()
 	return true;
 }
 
+boolean saucemavenApplies(item it)
+{
+	static boolean[item] saucy_foods = $items[Cold hi mein,
+		Devil hair pasta,
+		Fettris,
+		Fettucini Inconnu,
+		Fleetwood mac 'n' cheese,
+		Fusillocybin,
+		Gnocchetti di Nietzsche,
+		Haunted Hell ramen,
+		Hell ramen,
+		Hot hi mein,
+		Libertagliatelle,
+		Linguini immondizia bianco,
+		Linguini of the sea,
+		Prescription noodles,
+		Shells a la shellfish,
+		Sleazy hi mein,
+		Spagecialetti,
+		Spaghetti con calaveras,
+		Spaghetti with Skullheads,
+		Spooky hi mein,
+		Stinky hi mein,
+		Turkish mostaccioli];
+	return saucy_foods contains it;
+}
+
 float expectedAdventuresFrom(item it)
 {
 	if(it == $item[magical sausage]) return 1;
@@ -91,6 +118,11 @@ float expectedAdventuresFrom(item it)
 		return (s[1].to_int() + s[0].to_int())/2.0;
 	}
 	float expected = parse();
+	if(sl_have_skill($skill[Saucemaven]) && saucemavenApplies(it))
+	{
+		if (my_class() == $class[Sauceror]) expected += 5;
+		else expected += 3;
+	}
 	//if (item_amount($item[black label]) > 0 && $items[bottle of gin, bottle of rum, bottle of tequila, bottle of vodka or bottle of whiskey] contains it)
 	//	expected += 3.5;
 	return expected;

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -409,8 +409,28 @@ boolean slOverdrink(int howMany, item toOverdrink)
 	return overdrink(howMany, toOverdrink);
 }
 
+string cafeFoodName(int id)
+{
+	if (id == daily_special().to_int())
+	{
+		return daily_special().to_string();
+	}
+	switch(id)
+	{
+	case -1: return "Peche a la Frog";
+	case -2: return "As Jus Gezund Heit";
+	case -3: return "Bouillabaise Coucher Avec Moi";
+	default: abort("slDrinkCafe does not recognize item id: " + id);
+	}
+	return "";
+}
+
 string cafeDrinkName(int id)
 {
+	if (id == daily_special().to_int())
+	{
+		return daily_special().to_string();
+	}
 	switch(id)
 	{
 	case -1: return "Petite Porter";
@@ -426,17 +446,30 @@ boolean slDrinkCafe(int howmany, int id)
 	// Note that caller is responsible for calling Ode to Booze,
 	// since we might be in TCRS and not know how many adventures
 	// we'll get from the drink.
+	if(!gnomads_available()) return false;
+
 	string name = cafeDrinkName(id);
-	boolean canDesert = (get_property("lastDesertUnlock").to_int() == my_ascensions());
-	if(gnomads_available())
+	for (int i=0; i<howmany; i++)
 	{
-		for (int i=0; i<howmany; i++)
-		{
-			// TODO: What if we run out of meat?
-			visit_url("cafe.php?cafeid=2");
-			visit_url("cafe.php?pwd="+my_hash()+"&phash="+my_hash()+"&cafeid=2&whichitem="+id+"&action=CONSUME!");
-			handleTracker(name, "sl_drunken");
-		}
+		// TODO: What if we run out of meat?
+		visit_url("cafe.php?cafeid=2");
+		visit_url("cafe.php?pwd="+my_hash()+"&phash="+my_hash()+"&cafeid=2&whichitem="+id+"&action=CONSUME!");
+		handleTracker(name, "sl_drunken");
+	}
+	return true;
+}
+
+boolean slEatCafe(int howmany, int id)
+{
+	if(!canadia_available()) return false;
+
+	string name = cafeFoodName(id);
+	for (int i=0; i<howmany; i++)
+	{
+		// TODO: What if we run out of meat?
+		visit_url("cafe.php?cafeid=1");
+		visit_url("cafe.php?pwd="+my_hash()+"&phash="+my_hash()+"&cafeid=2&whichitem="+id+"&action=CONSUME!");
+		handleTracker(name, "sl_eaten");
 	}
 	return true;
 }
@@ -1498,22 +1531,31 @@ void consumeStuff()
 	}
 }
 
-boolean sl_knapsackAutoEat(boolean simulate)
+boolean loadConsumables(string _type, item[int] item_backmap, int[int] cafe_backmap, float[int] adv, int[int] space)
 {
-	// TODO: Doesn't yet use Canadian cafe food.
+	// type is "eat" or "drink"
+	int EAT   = 3;
+	int DRINK = 5;
+	int type  = 0;
+	if (_type == "eat")   type = EAT;
+	else if (_type == "drink") type = DRINK;
+	else return false;
 
-	if(fullness_left() == 0) return false;
-
-	if (item_amount($item[van key]) > 0)
+	boolean canConsume(item it)
 	{
-		use(item_amount($item[van key]), $item[van key]);
+		return type == EAT ? canEat(it) : canDrink(it);
 	}
 
-	int[int] fullness;
-	float[int] adv;
+	int organLeft()
+	{
+		return type == EAT ? fullness_left() : inebriety_left();
+	}
 
-	// Since backtracking prioritizes the first elements in the input array,
-	// we put small owned items, then buyables, then large owned, then craftables
+	int organCost(item it)
+	{
+		return type == EAT ? it.fullness : it.inebriety;
+	}
+
 	int[item] small_owned;
 	int[item] buyables;
 	int[item] large_owned;
@@ -1521,10 +1563,13 @@ boolean sl_knapsackAutoEat(boolean simulate)
 
 	foreach it in $items[]
 	{
-		if ((it.quality == "awesome" || it.quality == "EPIC") && canEat(it) && (it.fullness > 0) && is_unrestricted(it) && historical_price(it) <= 20000)
+		if (canConsume(it) && (organCost(it) > 0) && is_unrestricted(it) && historical_price(it) <= 20000)
 		{
-			int howmany = 1 + fullness_left()/it.fullness;
-			if (item_amount(it) > 0 && it.fullness <= 5)
+			if((it == $item[astral pilsner] || it == $item[Cold One]) && my_level() < 11) continue;
+			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
+
+			int howmany = 1 + organLeft()/organCost(it);
+			if (item_amount(it) > 0 && organCost(it) <= 5)
 			{
 				small_owned[it] = min(max(item_amount(it) - sl_reserveAmount(it), 0), howmany);
 			}
@@ -1537,7 +1582,7 @@ boolean sl_knapsackAutoEat(boolean simulate)
 			{
 				buyables[it] += min(howmany, my_meat() / 500);
 			}
-			if (item_amount(it) > 0 && it.fullness > 5)
+			if (item_amount(it) > 0 && organCost(it) > 5)
 			{
 				large_owned[it] = min(max(item_amount(it) - sl_reserveAmount(it), 0), howmany);
 			}
@@ -1549,15 +1594,17 @@ boolean sl_knapsackAutoEat(boolean simulate)
 		}
 	}
 
-	item[int] item_backmap;
 	void add(item it, boolean crafting, int howmany)
 	{
 		for (int i = 0; i < howmany; i++)
 		{
-			int n = count(fullness);
-			fullness[n] = it.fullness;
+			int n = count(space);
+			space[n] = organCost(it);
 			adv[n] = expectedAdventuresFrom(it);
-			adv[n] += min(1.0, item_amount($item[special seasoning]).to_float() * it.fullness / fullness_left());
+			if (type == EAT && is_unrestricted($item[special seasoning]))
+			{
+				adv[n] += min(1.0, item_amount($item[special seasoning]).to_float() * it.fullness / fullness_left());
+			}
 			if (crafting)
 			{
 				int turns_to_craft = creatable_turns(it, i + 1, false) - creatable_turns(it, i, false);
@@ -1584,138 +1631,118 @@ boolean sl_knapsackAutoEat(boolean simulate)
 		add(it, true, howmany);
 	}
 
-	int[item] foods;
-	float total_adv = 0.0;
-	int total_foods = 0;
-	print("Knapsack food plan:", "blue");
-	foreach i in knapsack(fullness_left(), count(fullness), fullness, adv)
-	{
-		foods[item_backmap[i]] += 1;
-		string name = item_backmap[i];
-		print(adv[i] + " adventures from " + name + "(" + fullness[i] + " fullness)", "blue");
-		total_adv += adv[i];
-		total_foods += 1;
-	}
-	print("(including +" + min(item_amount($item[special seasoning]), total_foods) + " from special seasoning ("+ item_amount($item[special seasoning]) + " available)", "blue");
-	total_adv += min(item_amount($item[special seasoning]), total_foods);
-	print("For a total of: " + total_adv + " adventures.", "blue");
+	// Now, to load cafe consumables. This has some TCRS-specific code.
 
-	if(count(foods) == 0)
+	if(type == DRINK && !gnomads_available()) return false;
+	if(type == EAT && !canadia_available()) return false;
+
+	// Add daily special
+	int daily_special_limit = 1 + min(my_meat()/(3*autosell_price(daily_special())), organLeft()/organCost(daily_special()));
+	for (int i=0; i < daily_special_limit; i++)
 	{
-		print("Couldn't find a way of finishing off our stomach space exactly.", "red");
-		return false;
+		int n = count(space);
+		space[n] = organCost(daily_special());
+		adv[n] = expectedAdventuresFrom(daily_special());
+		cafe_backmap[n] = daily_special().to_int();
 	}
 
-	if(!canSimultaneouslyAcquire(foods))
+	if(!in_tcrs()) 
 	{
-		print("Looks like I can't simultaneously acquire all of those items. I'm a bit confused. I'll wait and see if I get unconfused - otherwise, please eat manually.", "red");
-		return false;
-	}
-
-	if(simulate) return true;
-
-	if (count(foods) > 0)
-	{
-		foreach what, howmany in foods
+		// write in hard-coded adventure values for IPA, the best one
+		if(type == DRINK)
 		{
-			retrieve_item(howmany, what);
+			// Gnomish Microbrewery has a single best drink
+			int limit = 1 + min(my_meat()/100, inebriety_left()/3);
+			for (int i=0; i < limit; i++)
+			{
+				int n = count(space);
+				space[n] = 3;
+				adv[n] = 11.0/3.0;
+				cafe_backmap[n] = -3;
+			}
 		}
-		if (in_tcrs() && get_property("sl_useWishes").to_boolean() && (0 == have_effect($effect[Got Milk])))
+		if(type == EAT)
 		{
-			// +15 adv is worth it for daycount
-			// TODO: Some folks have requested a setting to turn this off.
-			makeGenieWish($effect[Got Milk]);
-		}
-		else dealwithMilkOfMagnesium(true);
+			// Chez Snootee does not have a single best food
 
-		foreach what, howmany in foods
-		{
-			slEat(howmany, what);
+			// Peche a la Frog
+			int limit = 1 + min(my_meat()/50, fullness_left()/3);
+			for (int i=0; i < limit; i++)
+			{
+				int n = count(space);
+				space[n] = 3;
+				adv[n] = 3.5;
+				cafe_backmap[n] = -1;
+			}
+
+			// As Jus Gezund Heit
+			limit = 1 + min(my_meat()/75, fullness_left()/4);
+			for (int i=0; i < limit; i++)
+			{
+				int n = count(space);
+				space[n] = 4;
+				adv[n] = 5.0;
+				cafe_backmap[n] = -2;
+			}
+
+			// As Jus Gezund Heit
+			limit = 1 + min(my_meat()/100, fullness_left()/4);
+			for (int i=0; i < limit; i++)
+			{
+				int n = count(space);
+				space[n] = 5;
+				adv[n] = 7.0;
+				cafe_backmap[n] = -3;
+			}
 		}
 		return true;
 	}
-	return false;
-}
 
-boolean loadDrinks(item[int] item_backmap, float[int] adv, int[int] inebriety)
-{
-	int[item] small_owned;
-	int[item] buyables;
-	int[item] large_owned;
-	int[item] craftables;
+	record _CAFE_CONSUMABLE_TYPE {
+		string name;
+		int space;
+		string quality;
+	};
 
-	foreach it in $items[]
+	_CAFE_CONSUMABLE_TYPE [int] cafe_stuff;
+	string filename = "";
+	if (type == DRINK)
+		filename = "TCRS_" + my_class().to_string().replace_string(" ", "_") + "_" + my_sign() + "_cafe_booze.txt";
+	else if (type == EAT)
+		filename = "TCRS_" + my_class().to_string().replace_string(" ", "_") + "_" + my_sign() + "_cafe_food.txt";
+
+	print("Loading " + filename, "blue");
+	if(!file_to_map(filename, cafe_stuff))
 	{
-		if ((it.quality == "awesome" || it.quality == "EPIC") && canEat(it) && (it.inebriety > 0) && is_unrestricted(it) && historical_price(it) <= 20000)
+		print("Something went wrong while trying to load " + filename + ". Maybe run 'tcrs load'?", "red");
+		abort();
+	}
+	foreach i, r in cafe_stuff
+	{
+		// Always-available cafe items have item ids -1, -2, -3
+		if (i >= -3 && r.space > 0)
 		{
-			int howmany = 1 + inebriety_left()/it.inebriety;
-			if (item_amount(it) > 0 && it.inebriety <= 5)
+			int limit = 1 + min(my_meat()/100, organLeft()/r.space);
+			for (int j=0; j<limit; j++)
 			{
-				small_owned[it] = min(max(item_amount(it) - sl_reserveAmount(it), 0), howmany);
-			}
-			if (npc_price(it) > 0)
-			{
-				howmany = min(howmany, my_meat() / npc_price(it));
-				buyables[it] = min(howmany, my_meat() / npc_price(it));
-			}
-			else if (buy_price($coinmaster[hermit], it) > 0)
-			{
-				buyables[it] += min(howmany, my_meat() / 500);
-			}
-			if (item_amount(it) > 0 && it.inebriety > 5)
-			{
-				large_owned[it] = min(max(item_amount(it) - sl_reserveAmount(it), 0), howmany);
-			}
-			if (creatable_amount(it) > 0)
-			{
-				howmany = min(howmany, max(0, creatable_amount(it) - sl_reserveCraftAmount(it)));
-				craftables[it] = howmany;
+				int n = count(space);
+				space[n] = r.space;
+				adv[n] = r.space * tcrs_expectedAdvPerFill(r.quality);
+				cafe_backmap[n] = i;
 			}
 		}
-	}
-
-	void add(item it, boolean crafting, int howmany)
-	{
-		for (int i = 0; i < howmany; i++)
-		{
-			int n = count(inebriety);
-			inebriety[n] = it.inebriety;
-			adv[n] = expectedAdventuresFrom(it);
-			if (crafting)
-			{
-				int turns_to_craft = creatable_turns(it, i + 1, false) - creatable_turns(it, i, false);
-				adv[n] -= turns_to_craft;
-			}
-			item_backmap[n] = it;
-		}
-	}
-
-	foreach it, howmany in small_owned
-	{
-		add(it, false, howmany);
-	}
-	foreach it, howmany in buyables
-	{
-		add(it, false, howmany);
-	}
-	foreach it, howmany in large_owned
-	{
-		add(it, false, howmany);
-	}
-	foreach it, howmany in craftables
-	{
-		add(it, true, howmany);
 	}
 	return true;
 }
 
-item sl_bestNightcap()
+void sl_autoDrinkNightcap(boolean simulate)
 {
 	int[int] inebriety;
 	float[int] adv;
 	item[int] item_backmap;
+	int[int] cafe_backmap;
 
-	loadDrinks(item_backmap, adv, inebriety);
+	loadConsumables("drink", item_backmap, cafe_backmap, adv, inebriety);
 
 	boolean have_ode = sl_have_skill($skill[The Ode to Booze]);
 	float advs_from(int i)
@@ -1731,96 +1758,21 @@ item sl_bestNightcap()
 	{
 		if (advs_from(i) > advs_from(best)) best = i;
 	}
-	return item_backmap[best];
-}
 
-boolean sl_knapsackAutoDrink(boolean simulate)
-{
-	// TODO: does not consider mime army shotglass
-	if (inebriety_left() == 0) return false;
+	string name = (cafe_backmap contains best) ? cafeDrinkName(cafe_backmap[best]) : item_backmap[best];
+	print("Nightcap is a " + name + " for " + advs_from(best) + " adventures.");
 
-	if (item_amount($item[unremarkable duffel bag]) > 0)
+	if (simulate) return;
+
+	if (item_backmap contains best)
 	{
-		use(item_amount($item[unremarkable duffel bag]), $item[unremarkable duffel bag]);
+		slDrink(1, item_backmap[best]);
 	}
-
-	int[int] inebriety;
-	float[int] adv;
-
-	int [int] cafe_backmap;
-	tcrs_loadCafeDrinks(cafe_backmap, adv, inebriety);
-
-	item[int] item_backmap;
-	loadDrinks(item_backmap, adv, inebriety);
-
-	int[item] normal_drinks;
-	int[int] cafe_drinks;
-
-	int liver_space = inebriety_left();
-	boolean saving_for_stooper = sl_have_familiar($familiar[Stooper]) && my_familiar() != $familiar[Stooper];
-	if (saving_for_stooper)
+	else
 	{
-		liver_space += 1;
+		buffMaintain($effect[Ode to Booze], 20, 1, inebriety[best]);
+		slDrinkCafe(1, cafe_backmap[best]);
 	}
-
-	boolean[int] result = knapsack(liver_space, count(inebriety), inebriety, adv);
-	print("Knapsack drink plan:", "blue");
-	float total_adv = 0.0;
-	foreach i in result
-	{
-		string name;
-		if (cafe_backmap contains i)
-		{
-			name = cafeDrinkName(cafe_backmap[i]);
-			cafe_drinks[cafe_backmap[i]] += 1;
-		}
-		else
-		{
-			name = to_string(item_backmap[i]);
-			normal_drinks[item_backmap[i]] += 1;
-		}
-		print(adv[i] + " adventures from " + name + "(" + inebriety[i] + " inebriety)", "blue");
-		total_adv += adv[i];
-	}
-	print("For a total of: " + total_adv + " adventures.", "blue");
-
-	if(count(result) == 0)
-	{
-		print("Couldn't find a way of finishing off our liver space exactly.", "red");
-		return false;
-	}
-
-	if(!canSimultaneouslyAcquire(normal_drinks))
-	{
-		print("It looks like I can't simultaneously get everything that I want to drink. I'll wait and see if I get unconfused - otherwise, please drink manually.", "red");
-		return false;
-	}
-
-	if(simulate) return true;
-
-	foreach i in result
-	{
-		if(inebriety[i] >= inebriety_left() && !get_property("_sl_saving_for_stooper").to_boolean())
-		{
-			print("Leaving some liver space left for Stooper...");
-			set_property("_sl_saving_for_stooper", true);
-			break;
-		}
-
-		if (cafe_backmap contains i)
-		{
-			int what = cafe_backmap[i];
-			buffMaintain($effect[Ode to Booze], 20, 1, inebriety_left());
-			slDrinkCafe(1, what);
-		}
-		else
-		{
-			item what = item_backmap[i];
-			retrieve_item(1, what);
-			slDrink(1, what);
-		}
-	}
-	return true;
 }
 
 boolean sl_autoDrinkOne(boolean simulate)
@@ -1831,10 +1783,8 @@ boolean sl_autoDrinkOne(boolean simulate)
 	float[int] adv;
 
 	int [int] cafe_backmap;
-	tcrs_loadCafeDrinks(cafe_backmap, adv, inebriety);
-
 	item[int] item_backmap;
-	loadDrinks(item_backmap, adv, inebriety);
+	loadConsumables("drink", item_backmap, cafe_backmap, adv, inebriety);
 
 	int[item] normal_drinks;
 	int[int] cafe_drinks;
@@ -1868,7 +1818,141 @@ boolean sl_autoDrinkOne(boolean simulate)
 	else
 	{
 		string name = (cafe_backmap contains best_index) ? cafeDrinkName(cafe_backmap[best_index]) : item_backmap[best_index];
-		print("Would have drunk a " + name + " for " + adv[best_index] + " adventures and " + inebriety[best_index] + "inebriety.", "blue");
+		print("Would have drunk a " + name + " for " + adv[best_index] + " adventures and " + inebriety[best_index] + " inebriety.", "blue");
 		return true;
 	}
+}
+
+boolean sl_knapsackAutoConsume(string type, boolean simulate)
+{
+	// TODO: does not consider mime army shotglass
+
+	int organLeft()
+	{
+		if (type == "eat") return fullness_left();
+		if (type == "drink") return inebriety_left();
+		abort("Unrecognized organ type: should be 'eat' or 'drink', was " + type);
+		return 0;
+	}
+	if (organLeft() == 0) return false;
+
+	if (item_amount($item[unremarkable duffel bag]) > 0)
+	{
+		use(item_amount($item[unremarkable duffel bag]), $item[unremarkable duffel bag]);
+	}
+	if (item_amount($item[van key]) > 0)
+	{
+		use(item_amount($item[van key]), $item[van key]);
+	}
+
+	int[int] space;
+	float[int] adv;
+
+	int [int] cafe_backmap;
+	item[int] item_backmap;
+	loadConsumables(type, item_backmap, cafe_backmap, adv, space);
+
+	int[item] normal_consumables;
+
+	int remaining_space = organLeft();
+	boolean saving_for_stooper = type == "drink" && sl_have_familiar($familiar[Stooper]) && my_familiar() != $familiar[Stooper];
+	if (saving_for_stooper)
+	{
+		remaining_space += 1;
+	}
+	print("Space: " + remaining_space);
+	boolean[int] result = knapsack(remaining_space, count(space), space, adv);
+
+	print("Knapsack " + type + " plan:", "blue");
+	float total_adv = 0.0;
+	int consumable_count = 0;
+	int sum_space = 0;
+	foreach i in result
+	{
+		string name;
+		if (cafe_backmap contains i)
+		{
+			name = (type == "eat") ? cafeFoodName(cafe_backmap[i]) : cafeDrinkName(cafe_backmap[i]);
+		}
+		else
+		{
+			name = to_string(item_backmap[i]);
+			normal_consumables[item_backmap[i]] += 1;
+		}
+		consumable_count++;
+		sum_space += space[i];
+		string organ_name = (type == "eat") ? "fullness" : "inebriety";
+		print(adv[i] + " adventures from " + name + " (" + space[i] + " " + organ_name + ")", "blue");
+		total_adv += adv[i];
+	}
+	if (type == "eat")
+	{
+		print("(including +" + min(item_amount($item[special seasoning]), consumable_count) + " from special seasoning ("+ item_amount($item[special seasoning]) + " available)", "blue");
+	}
+	if (type == "drink" && sl_have_skill($skill[The Ode to Booze]))
+	{
+		print("(+" + sum_space + " from Ode to Booze)", "blue");
+		total_adv += sum_space;
+	}
+	print("For a total of: " + total_adv + " adventures.", "blue");
+
+	if(count(result) == 0)
+	{
+		print("Couldn't find a way of finishing off our " + type + " space exactly.", "red");
+		return false;
+	}
+
+	if(!canSimultaneouslyAcquire(normal_consumables))
+	{
+		print("It looks like I can't simultaneously get everything that I want to " + type + ". I'll wait and see if I get unconfused - otherwise, please " + type + " manually.", "red");
+		return false;
+	}
+
+	if(simulate) return true;
+
+	if(type == "eat")
+	{
+		if (in_tcrs() && get_property("sl_useWishes").to_boolean() && (0 == have_effect($effect[Got Milk])))
+		{
+			// +15 adv is worth it for daycount
+			// TODO: Some folks have requested a setting to turn this off.
+			makeGenieWish($effect[Got Milk]);
+		}
+		else dealwithMilkOfMagnesium(true);
+	}
+
+	foreach i in result
+	{
+		if((type == "drink") && space[i] >= inebriety_left() && !get_property("_sl_saving_for_stooper").to_boolean())
+		{
+			print("Saving some liver space left for Stooper...");
+			set_property("_sl_saving_for_stooper", true);
+			break;
+		}
+
+		if (cafe_backmap contains i)
+		{
+			int what = cafe_backmap[i];
+			if(type == "drink")
+			{
+				buffMaintain($effect[Ode to Booze], 20, 1, inebriety_left());
+				slDrinkCafe(1, what);
+			}
+			else if (type == "eat")
+			{
+				// TODO: implement slEatCafe
+				// slEatCafe(1, what);
+			}
+		}
+		else
+		{
+			item what = item_backmap[i];
+			retrieve_item(1, what);
+			if (type == "drink")
+				slDrink(1, what);
+			else if (type == "eat")
+				slEat(1, what);
+		}
+	}
+	return true;
 }

--- a/RELEASE/scripts/sl_ascend/sl_tcrs.ash
+++ b/RELEASE/scripts/sl_ascend/sl_tcrs.ash
@@ -33,8 +33,8 @@ float tcrs_expectedAdvPerFill(string quality)
 
 boolean tcrs_consumption()
 {
-	// if(!in_tcrs())
-	//	return false;
+	if(!in_tcrs())
+		return false;
 
 	if(sl_beta() && my_adventures() < 5)
 	{
@@ -56,12 +56,15 @@ boolean tcrs_consumption()
 			sl_knapsackAutoConsume("eat", false);
 			return true;
 		}
+		// Stooper requires more testing to be truly safe.
+		/*
 		if(my_adventures() <= 1 && inebriety_left() > 0 && get_property("_sl_saving_for_stooper").to_boolean())
 		{
 			use_familiar($familiar[Stooper]);
 			sl_knapsackAutoConsume("drink", false);
 			return true;
 		}
+		*/
 	}
 
 	if (sl_beta()) return true;

--- a/RELEASE/scripts/sl_ascend/sl_tcrs.ash
+++ b/RELEASE/scripts/sl_ascend/sl_tcrs.ash
@@ -31,43 +31,10 @@ float tcrs_expectedAdvPerFill(string quality)
 	return -1; // makes the compiler shut up
 }
 
-boolean tcrs_loadCafeDrinks(int[int] cafe_backmap, float[int] adv, int[int] inebriety)
-{
-	if(!in_tcrs()) return false;
-	if(!gnomads_available()) return false;
-
-	record _CAFE_DRINK_TYPE {
-		string name;
-		int inebriety;
-		string quality;
-	};
-
-	_CAFE_DRINK_TYPE [int] cafe_booze;
-	string filename = "TCRS_" + my_class().to_string().replace_string(" ", "_") + "_" + my_sign() + "_cafe_booze.txt";
-	print("Loading " + filename, "blue");
-	file_to_map(filename, cafe_booze);
-	foreach i, r in cafe_booze
-	{
-		// Gnomish Microbrewery has item ids -1, -2, -3
-		if (i >= -3 && r.inebriety > 0)
-		{
-			int limit = 1 + min(my_meat()/100, inebriety_left()/r.inebriety);
-			for (int j=0; j<limit; j++)
-			{
-				int n = count(inebriety);
-				inebriety[n] = r.inebriety;
-				adv[n] = r.inebriety * tcrs_expectedAdvPerFill(r.quality);
-				cafe_backmap[n] = i;
-			}
-		}
-	}
-	return true;
-}
-
 boolean tcrs_consumption()
 {
-	if(!in_tcrs())
-		return false;
+	// if(!in_tcrs())
+	//	return false;
 
 	if(sl_beta() && my_adventures() < 5)
 	{
@@ -80,18 +47,19 @@ boolean tcrs_consumption()
 		}
 		if(inebriety_left() > 0 && !get_property("_sl_saving_for_stooper").to_boolean())
 		{
-			sl_knapsackAutoDrink(false);
+			use_familiar($familiar[none]);
+			sl_knapsackAutoConsume("drink", false);
 			return true;
 		}
 		if(fullness_left() > 0)
 		{
-			sl_knapsackAutoEat(false);
+			sl_knapsackAutoConsume("eat", false);
 			return true;
 		}
 		if(my_adventures() <= 1 && inebriety_left() > 0 && get_property("_sl_saving_for_stooper").to_boolean())
 		{
 			use_familiar($familiar[Stooper]);
-			sl_knapsackAutoDrink(false);
+			sl_knapsackAutoConsume("drink", false);
 			return true;
 		}
 	}

--- a/RELEASE/scripts/sl_ascend/sl_test.ash
+++ b/RELEASE/scripts/sl_ascend/sl_test.ash
@@ -1,0 +1,60 @@
+script "sl_test.ash"
+
+import <sl_ascend.ash>
+
+boolean passed;
+
+void assertTrue(boolean val, string message)
+{
+	if (!val)
+	{
+		print("Assertion failed: " + message, "red");
+	}
+	passed &= val;
+}
+
+void testLoadConsumables()
+{
+	item[int] item_backmap;
+	int[int] cafe_backmap;
+	float[int] adv;
+	int[int] space;
+	loadConsumables("eat", item_backmap, cafe_backmap, adv, space);
+
+	void assertContains(item searchFor, string message)
+	{
+		boolean found = false;
+		foreach i, it in item_backmap
+		{
+			if (it == searchFor) found = true;
+		}
+		assertTrue(found, message);
+	}
+
+	assertTrue(count(item_backmap) > 0, "item_backmap should be nonempty");
+	assertTrue(count(adv) > 0, "adv should be nonempty");
+	assertTrue(count(space) > 0, "space should be nonempty");
+	assertContains($item[catsup], "hermit items should be present");
+	if (canadia_available()) assertTrue(0 < count(cafe_backmap), "In Canadia moonsign: Cafe items should be loaded");
+	if (!canadia_available()) assertTrue(0 == count(cafe_backmap), "Not in Canadia moonsign: Cafe items should not be loaded");
+}
+
+void testKnapsackAutoConsume()
+{
+	sl_knapsackAutoConsume("eat", true);
+	sl_knapsackAutoConsume("drink", true);
+}
+
+void main()
+{
+	void runTest(string name)
+	{
+		passed = true;
+		call void name();
+		string color = passed ? "green" : "red";
+		string sstatus = passed ? "PASS" : "FAIL";
+		print(name + ": " + sstatus, color);
+	}
+	runTest("testLoadConsumables");
+	runTest("testKnapsackAutoConsume");
+}

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -5891,8 +5891,9 @@ boolean[int] knapsack(int maxw, int n, int[int] weight, float[int] val)
 		// If so, we took this item.
 		if (V[i][w] != V[i-1][w])
 		{
-			w -= weight[i-1];
 			ret[i-1] = true;
+			w -= weight[i-1];
+			i -= 1;
 		}
 		else
 		{
@@ -5908,6 +5909,9 @@ boolean[int] knapsack(int maxw, int n, int[int] weight, float[int] val)
 
 int sl_reserveAmount(item it)
 {
+	// Hard-code to avoid infinite loop between wad of dough and flat dough
+	if(it == $item[wad of dough] || it == $item[flat dough]) return 0;
+
 	string [string,int,string] itemdata;
 	if(!file_to_map("sl_ascend_items.txt", itemdata))
 		print("Could not load sl_ascend_items.txt! This is bad!", "red");
@@ -5936,6 +5940,9 @@ int sl_reserveAmount(item it)
 
 int sl_reserveCraftAmount(item it)
 {
+	// Hard-code to avoid infinite loop between wad of dough and flat dough
+	if(it == $item[wad of dough] || it == $item[flat dough]) return 0;
+
 	int reserve = 0;
 	foreach ing,amt in get_ingredients(it)
 	{

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -5909,9 +5909,6 @@ boolean[int] knapsack(int maxw, int n, int[int] weight, float[int] val)
 
 int sl_reserveAmount(item it)
 {
-	// Hard-code to avoid infinite loop between wad of dough and flat dough
-	if(it == $item[wad of dough] || it == $item[flat dough]) return 0;
-
 	string [string,int,string] itemdata;
 	if(!file_to_map("sl_ascend_items.txt", itemdata))
 		print("Could not load sl_ascend_items.txt! This is bad!", "red");
@@ -5940,9 +5937,6 @@ int sl_reserveAmount(item it)
 
 int sl_reserveCraftAmount(item it)
 {
-	// Hard-code to avoid infinite loop between wad of dough and flat dough
-	if(it == $item[wad of dough] || it == $item[flat dough]) return 0;
-
 	int reserve = 0;
 	foreach ing,amt in get_ingredients(it)
 	{


### PR DESCRIPTION
Still hidden behind `sl_beta`. I'm disabling the "let's do a last drink with Stooper" logic because it's not quite correct (it needs to be moved into doBedtime() so we can do our free fights with a +xp familiar without being fall-down drunk).

Also fix a lingering Baa'baa'buran issue, where we'd only wish to fight Baa' in one of the two cases where we needed wool.

Also add `sl_test.ash`. My plan is to throw random sanity checks in there. It's a pity stuff like `item_amount(it)` isn't mockable.