### PR TITLE
More optimized Smut Orc Camp

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -212,6 +212,7 @@ void initializeSettings()
 	set_property("sl_treecoin", "");
 	set_property("sl_twinpeak", "");
 	set_property("sl_twinpeakprogress", "");
+	set_property("sl_useSpellsInOrcCamp", false);
 	set_property("sl_waitingArrowAlcove", "50");
 	set_property("sl_wandOfNagamar", true);
 	set_property("sl_war", "");
@@ -12703,8 +12704,56 @@ boolean L9_chasmBuild()
 		return true;
 	}
 
+	// -Combat is useless here since NC is triggered by killing Orcs...So we kill orcs better!
+	asdonBuff($effect[Driving Intimidatingly]);
+
+	// Check our Load out to see if spells are the best option for Orc-Thumping
+	if(setFlavour($element[cold]) && canUse($skill[Stuffed Mortar Shell]))
+	{
+		set_property("sl_useSpellsInOrcCamp", true);
+	}
+
+	if(setFlavour($element[cold]) && canUse($skill[Cannelloni Cannon]))
+	{
+	set_property("sl_useSpellsInOrcCamp", true);
+	}
+
+	if(canUse($skill[Saucegeyser]))
+	{
+		set_property("sl_useSpellsInOrcCamp", true);
+	}
+
+	if(canUse($skill[Saucecicle]))
+	{
+		set_property("sl_useSpellsInOrcCamp", true);
+	}
+
+	// Always Maximize and choose our default Non-Com First, in case we are wrong about the non-com we MAY have some gear still equipped to help us.
+	if(get_property("sl_useSpellsInOrcCamp").to_boolean())
+	{
+		print("Preparing to Blast Orcs with Cold Spells!", "blue");
+		addToMaximize("myst,20spell damage,40spell damage percent,20cold spell damage,-100 ml");
+		buffMaintain($effect[Carol of the Hells], 50, 1, 1);
+		buffMaintain($effect[Song of Sauce], 150, 1, 1);
+
+		// Since we are Buffing for Spells and Myst, set choice adventure just in case
+		set_property("choiceAdventure1345", 2);
+	}
+	else
+	{
+		print("Preparing to Ice-Punch Orcs!", "blue");
+		addToMaximize("muscle,50weapon damage,40weapon damage percent,20cold damage,-100 ml");
+		buffMaintain($effect[Carol of the Bulls], 50, 1, 1);
+		buffMaintain($effect[Song of The North], 150, 1, 1);
+
+		// Since we are Buffing for Weapons and Muscle, set choice adventure just in case
+		set_property("choiceAdventure1345", 1);
+        }
+
 	if(get_property("smutOrcNoncombatProgress").to_int() == 15)
 	{
+		// If we think the non-com will hit NOW we clear maximizer to keep previous settings from carrying forward
+		resetMaximize();
 		print("The smut orc noncombat is about to hit...");
 		// This is a hardcoded patch for Dark Gyffte
 		// TODO: once explicit formulas are spaded, use simulated maximizer

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -12791,15 +12791,6 @@ boolean L9_chasmBuild()
 		slAdv(1, $location[The Smut Orc Logging Camp]);
 		return true;
 	}
-	else
-	{
-		if(setFlavour($element[cold]) && sl_have_skill($skill[Stuffed Mortar Shell]))
-		{
-			addToMaximize("20spell damage,80spell damage percent,20cold spell damage,-10ml");
-			buffMaintain($effect[Carol of the Hells], 50, 1, 1);
-			buffMaintain($effect[Song of Sauce], 150, 1, 1);
-		}
-	}
 
 	if(in_hardcore())
 	{

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -1414,9 +1414,29 @@ string sl_combatHandler(int round, string opp, string text)
 			}
 		}
 
-		if(my_location() == $location[The Smut Orc Logging Camp] && canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0 && canSurvive(1.0))
+		if(my_location() == $location[The Smut Orc Logging Camp] && canSurvive(1.0))
 		{
-			return useSkill($skill[Stuffed Mortar Shell]);
+			// Listed from Most to Least Damaging to hopefully cause Death on the turn when the Shell hits.
+			if(canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0)
+			{
+				return useSkill($skill[Stuffed Mortar Shell]);
+			}
+			else if(canUse($skill[Saucegeyser]))
+			{
+				return useSkill($skill[Saucegeyser]);
+			}
+			else if(canUse($skill[Saucecicle]))
+			{
+				return useSkill($skill[Saucecicle]);
+			}
+			else if(canUse($skill[Cannelloni Cannon]) && have_effect($effect[Spirit of Peppermint]) != 0)
+			{
+				return useSkill($skill[Cannelloni Cannon]);
+			}
+			else if(canUse($skill[Northern Explosion]))
+			{
+				return useSkill($skill[Northern Explosion]);
+			}
 		}
 
 		if(my_location() == $location[The Haunted Kitchen] && equipped_amount($item[vampyric cloake]) > 0 && get_property("_vampyreCloakeFormUses").to_int() < 10)


### PR DESCRIPTION
Added - Optimization for Smut Orc quest. In testing saved 10 turns without having the most effective skills.

Essentially a better attempt at "Brute Forcing" the Quest. Instead of relying on every 15th adv we try to play to our strengths in every combat and rely on getting the Non-Com more frequently.

I left in the every 15th non-com prep because it is more beneficial to newblets without lots of perms or shinies, an area that my method doesn't cover well. I figured this would be a good middle ground, and wouldn't be too detrimental to people with the aforementioned benefits.