### PR TITLE
Consider TCRS changes for drinking Steel Margarita

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -9738,11 +9738,14 @@ boolean LX_steelOrgan()
 	else if(get_property("questM10Azazel") == "finished")
 	{
 		print("Considering Steel Organ consumption.....", "blue");
-		if((item_amount($item[Steel Lasagna]) > 0) && (fullness_left() >= 5))
+		if((item_amount($item[Steel Lasagna]) > 0) && (fullness_left() >= $item[Steel Lasagna].fullness))
 		{
 			eatsilent(1, $item[Steel Lasagna]);
 		}
-		if((item_amount($item[Steel Margarita]) > 0) && ((my_inebriety() <= 5) || (my_inebriety() >= 12)))
+		boolean wontBeOverdrunk = inebriety_left() >= $item[Steel Margarita].inebriety - 5;
+		boolean notOverdrunk = my_inebriety() <= inebriety_limit();
+		boolean notSavingForBilliards = hasSpookyravenLibraryKey() || get_property("lastSecondFloorUnlock").to_int() == my_ascensions();
+		if((item_amount($item[Steel Margarita]) > 0) && wontBeOverdrunk && notOverdrunk && (notSavingForBilliards || my_inebriety() + $item[Steel Margarita].inebriety <= 10 || my_inebriety() >= 12))
 		{
 			slDrink(1, $item[Steel Margarita]);
 		}

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1694,7 +1694,7 @@ boolean loadConsumables(string _type, item[int] item_backmap, int[int] cafe_back
 	if(type == EAT && !canadia_available()) return false;
 
 	// Add daily special
-	if (canConsume(daily_special()))
+	if (daily_special() != $item[none] && canConsume(daily_special()))
 	{
 		int daily_special_limit = 1 + min(my_meat()/(3*autosell_price(daily_special())), organLeft()/organCost(daily_special()));
 		for (int i=0; i < daily_special_limit; i++)

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1696,7 +1696,7 @@ boolean loadConsumables(string _type, item[int] item_backmap, int[int] cafe_back
 	// Add daily special
 	if (daily_special() != $item[none] && canConsume(daily_special()))
 	{
-		int daily_special_limit = 1 + min(my_meat()/(3*autosell_price(daily_special())), organLeft()/organCost(daily_special()));
+		int daily_special_limit = 1 + min(my_meat()/(3*min(35, autosell_price(daily_special()))), organLeft()/organCost(daily_special()));
 		for (int i=0; i < daily_special_limit; i++)
 		{
 			int n = count(space);


### PR DESCRIPTION
"HC TCRS, DB Packrat: The script just overdrank with the Steel Margarita before eating any food."

Steel Margarita is 6 inebriety in that TCRS path/sign combination, so drinking it when we're already capped out on drinks for the day will result in going overdrunk.

I haven't actually run this, so my hope is that the change is self-evident enough that it's correct by inspection.