### PR TITLE
Refactor auto-consumption to be smart in softcore

### DIFF
--- a/RELEASE/scripts/postsool.ash
+++ b/RELEASE/scripts/postsool.ash
@@ -412,6 +412,11 @@ void handlePostAdventure()
 		useCocoon();
 	}
 
+	if((my_maxhp() > 200) && (my_hp() < 140) && (my_mp() > 100))
+	{
+		useCocoon();
+	}
+
 
 	if(sl_have_skill($skill[Thunderheart]) && (my_thunder() >= 90) && ((my_turncount() - get_property("sl_lastthunderturn").to_int()) >= 9))
 	{
@@ -459,6 +464,7 @@ void handlePostAdventure()
 		{
 			buffMaintain($effect[Empathy], 25, 1, 10);
 		}
+		// TODO: 'Get Big' is a pretty good skill
 		if((libram != $skill[none]) && ((my_mp() - mp_cost(libram)) > 25))
 		{
 			use_skill(1, libram);

--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -132,6 +132,12 @@ void handlePreAdventure(location place)
 		uneffect($effect[Scarysauce]);
 	}
 
+	if($locations[Next to that Barrel with something Burning In It, Near an Abandoned Refrigerator, Over where the Old Tires Are, Out by that Rusted-Out Car] contains place)
+	{
+		uneffect($effect[Spiky Shell]);
+		uneffect($effect[Scarysauce]);
+	}
+
 	if(my_path() == $class[Avatar of Boris])
 	{
 		if((have_effect($effect[Song of Solitude]) == 0) && (have_effect($effect[Song of Battle]) == 0))
@@ -313,6 +319,12 @@ void handlePreAdventure(location place)
 		cli_execute("checkpoint clear");
 	}
 	executeFlavour();
+
+	// After maximizing equipment, we might not be at full HP
+	if ($locations[Tower Level 1] contains place)
+	{
+		useCocoon();
+	}
 
 	if(in_hardcore() && (my_class() == $class[Sauceror]) && (my_mp() < 32))
 	{

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1598,10 +1598,7 @@ int handlePulls(int day)
 			{
 				pullXWhenHaveY($item[xiblaxian stealth cowl], 1, 0);
 			}
-			if (storage_amount($item[Pantsgiving]) > 0)
-			{
-				pullXWhenHaveY($item[Pantsgiving], 1, 0);
-			}
+			pullXWhenHaveY($item[Pantsgiving], 1, 0);
 		}
 		else
 		{

--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1598,7 +1598,10 @@ int handlePulls(int day)
 			{
 				pullXWhenHaveY($item[xiblaxian stealth cowl], 1, 0);
 			}
-			pullXWhenHaveY($item[Pantsgiving], 1, 0);
+			if (storage_amount($item[Pantsgiving]) > 0)
+			{
+				pullXWhenHaveY($item[Pantsgiving], 1, 0);
+			}
 		}
 		else
 		{

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1787,11 +1787,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	if(towerKeyCount() < 3)
 	{
-		if(item_amount($item[Boris's key]) == 0 && item_amount($item[phat loot token]) < 3)
+		if(item_amount($item[Boris's key]) == 0 && item_amount($item[fat loot token]) < 3)
 			wantBorisPie = true;
-		if(item_amount($item[Jarlsberg's key]) == 0 && item_amount($item[phat loot token]) < 2)
+		if(item_amount($item[Jarlsberg's key]) == 0 && item_amount($item[fat loot token]) < 2)
 			wantJarlsbergPie = true;
-		if(item_amount($item[Sneaky Pete's key]) == 0 && item_amount($item[phat loot token]) < 1)
+		if(item_amount($item[Sneaky Pete's key]) == 0 && item_amount($item[fat loot token]) < 1)
 			wantPetePie = true;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1785,14 +1785,13 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	boolean wantJarlsbergPie = false;
 	boolean wantPetePie = false;
 
-	if ((item_amount($item[Boris's key]) == 0) && (item_amount($item[Jarlsberg's key]) == 0) && (item_amount($item[Sneaky Pete's key]) == 0) && towerKeyCount() < 3)
+	if(towerKeyCount() < 3)
 	{
-		// I refuse to handle the hard case where someone has pulled and eaten a key
-		if (item_amount($item[fat loot token]) < 1)
+		if(item_amount($item[Boris's key]) == 0 && item_amount($item[phat loot token]) < 3)
 			wantBorisPie = true;
-		if (item_amount($item[fat loot token]) < 2)
+		if(item_amount($item[Jarlsberg's key]) == 0 && item_amount($item[phat loot token]) < 2)
 			wantJarlsbergPie = true;
-		if (item_amount($item[fat loot token]) < 3)
+		if(item_amount($item[Sneaky Pete's key]) == 0 && item_amount($item[phat loot token]) < 1)
 			wantPetePie = true;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1653,7 +1653,7 @@ boolean slPrepConsume(ConsumeAction action)
 
 boolean slConsume(ConsumeAction action)
 {
-	if (action.howToGet == SL_OBTAIN_PULL || action.howToGet == SL_OBTAIN_CRAFT)
+	if (action.howToGet != SL_OBTAIN_NULL)
 	{
 		abort("ConsumeAction not prepped: " + to_debug_string(action));
 	}
@@ -1738,7 +1738,12 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	foreach it in $items[]
 	{
-		if (canConsume(it) && (organCost(it) > 0) && is_unrestricted(it) && historical_price(it) <= 20000)
+		if (
+			canConsume(it) &&
+			(organCost(it) > 0) &&
+			(it.fullness == 0 || it.inebriety == 0) &&
+			is_unrestricted(it) &&
+			historical_price(it) <= 20000)
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One]) && my_level() < 11) continue;
 			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
@@ -1767,6 +1772,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			if (storage_amount(it) > 0 && is_tradeable(it))
 			{
 				pullables[it] = min(howmany, min(pulls_remaining(), storage_amount(it)));
+			}
+			boolean[item] KEY_LIME_PIES = $items[Boris's key lime pie, Jarlsberg's key lime pie, Sneaky Pete's key lime pie];
+			if ((KEY_LIME_PIES contains it) && !(pullables contains it))
+			{
+				pullables[it] = 1;
 			}
 		}
 	}

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1818,7 +1818,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				// Is this a good estimate of how many adventures a pull is worth? I don't know!
 				// This could be a property, I don't know.
-				actions[n].desirability -= 7.0;
+				actions[n].desirability -= 10.0;
 				actions[n].howToGet = SL_OBTAIN_PULL;
 			}
 			if (type == SL_ORGAN_STOMACH && is_unrestricted($item[special seasoning]))
@@ -1831,7 +1831,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 					(it == $item[Sneaky Pete's key lime pie] && wantPetePie)))
 			{
 				print("If we pulled and ate a " + it + " we could skip getting a fat loot token...");
-				actions[n].desirability += 100;
+				actions[n].desirability += 25;
 			}
 			if (crafting)
 			{

--- a/RELEASE/scripts/sl_ascend/sl_cooking.ash
+++ b/RELEASE/scripts/sl_ascend/sl_cooking.ash
@@ -1700,11 +1700,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		abort("We shouldn't be calling loadConsumables() in Dark Gyffte. Please report this.");
 	}
 
-	if (item_amount($item[unremarkable duffel bag]) > 0)
+	if ((item_amount($item[unremarkable duffel bag]) > 0) && (pulls_remaining() != -1))
 	{
 		use(item_amount($item[unremarkable duffel bag]), $item[unremarkable duffel bag]);
 	}
-	if (item_amount($item[van key]) > 0)
+	if ((item_amount($item[van key]) > 0) && (pulls_remaining() != -1))
 	{
 		use(item_amount($item[van key]), $item[van key]);
 	}

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -3265,8 +3265,6 @@ boolean handleSealElement(element flavor, string option)
 	return slAdvBypass(page, $location[Noob Cave], option);
 }
 
-
-
 int towerKeyCount()
 {
 	return towerKeyCount(true);
@@ -3701,7 +3699,7 @@ int sl_mall_price(item it)
 {
 	if(is_tradeable(it))
 	{
-		int retval = mall_price(it);
+		int retval = historical_price(it);
 		if(retval == -1)
 		{
 			abort("Failed getting mall price for " + it + ", aborting to prevent problems");
@@ -5819,10 +5817,8 @@ boolean canSimultaneouslyAcquire(int[item] needed)
 	// perfect drinks.
 	// Checks that a set of items isn't impossible to acquire because of
 	// conflicting crafting dependencies.
-
 	int[item] alreadyUsed;
 	int meatUsed;
-
 	boolean failed = false;
 	void addToAlreadyUsed(int amount, item toAdd)
 	{
@@ -5844,19 +5840,16 @@ boolean canSimultaneouslyAcquire(int[item] needed)
 			{
 				meatUsed += npc_price(toAdd);
 			}
-
 			foreach ing,ingAmount in get_ingredients(toAdd)
 			{
 				addToAlreadyUsed(ingAmount * needToCraft, ing);
 			}
 		}
 	}
-
 	foreach it, amt in needed
 	{
 		addToAlreadyUsed(amt, it);
 	}
-
 	return !failed && meatUsed <= my_meat();
 }
 

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -3699,7 +3699,7 @@ int sl_mall_price(item it)
 {
 	if(is_tradeable(it))
 	{
-		int retval = historical_price(it);
+		int retval = mall_price(it);
 		if(retval == -1)
 		{
 			abort("Failed getting mall price for " + it + ", aborting to prevent problems");
@@ -5817,8 +5817,10 @@ boolean canSimultaneouslyAcquire(int[item] needed)
 	// perfect drinks.
 	// Checks that a set of items isn't impossible to acquire because of
 	// conflicting crafting dependencies.
+
 	int[item] alreadyUsed;
 	int meatUsed;
+
 	boolean failed = false;
 	void addToAlreadyUsed(int amount, item toAdd)
 	{
@@ -5840,16 +5842,19 @@ boolean canSimultaneouslyAcquire(int[item] needed)
 			{
 				meatUsed += npc_price(toAdd);
 			}
+
 			foreach ing,ingAmount in get_ingredients(toAdd)
 			{
 				addToAlreadyUsed(ingAmount * needToCraft, ing);
 			}
 		}
 	}
+
 	foreach it, amt in needed
 	{
 		addToAlreadyUsed(amt, it);
 	}
+
 	return !failed && meatUsed <= my_meat();
 }
 

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2468,7 +2468,7 @@ boolean instakillable(monster mon)
 
 	boolean[monster] protectorspirits = $monsters[ancient protector spirit, ancient protector spirit (The Hidden Apartment Building), ancient protector spirit (The Hidden Hospital), ancient protector spirit (The Hidden Office Building), ancient protector spirit (The Hidden Bowling Alley)];
 
-	if($monster[Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl] == mon)
+	if($monsters[Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl, Eldritch Tentacle] contains mon)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -3745,6 +3745,11 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 				meat = my_meat() - 5000;
 				getFromStorage = false;
 			}
+			if (curPrice >= 30000)
+			{
+				print(it + " is too expensive at " + curPrice + " meat, we're gonna skip buying one in the mall.", "red");
+				break;
+			}
 			if((curPrice <= oldPrice) && (curPrice < 30000) && (meat >= curPrice))
 			{
 				if(getFromStorage)

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -2462,6 +2462,8 @@ boolean instakillable(monster mon)
 		return false;
 	}
 
+	boolean[monster] cyrptbosses = $monsters[conjoined zmombie, gargantulihc, giant skeelton, huge ghuol];
+
 	boolean[monster] timeSpinner = $monsters[Ancient Skeleton with Skin still on it, Apathetic Tyrannosaurus, Assembly Elemental, Cro-Magnon Gnoll, Krakrox the Barbarian, Wooly Duck];
 
 	boolean[monster] lovetunnel = $monsters[LOV Enforcer, LOV Engineer, LOV Equivocator];
@@ -2469,6 +2471,11 @@ boolean instakillable(monster mon)
 	boolean[monster] protectorspirits = $monsters[ancient protector spirit, ancient protector spirit (The Hidden Apartment Building), ancient protector spirit (The Hidden Hospital), ancient protector spirit (The Hidden Office Building), ancient protector spirit (The Hidden Bowling Alley)];
 
 	if($monsters[Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl, Eldritch Tentacle] contains mon)
+	{
+		return false;
+	}
+
+	if(cyrptbosses contains mon)
 	{
 		return false;
 	}


### PR DESCRIPTION
Posting this PR as a request for comment, since I'm still tweaking the weights on this.

Sample day 1 consumption in softcore standard:

`sl_eaten = (1:Jarlsberg's key lime pie:129), (1:Sneaky Pete's key lime              pie:129), (1:grue egg omelette:129), (1:meteoreo:129), (1:glass of raw eggs:129), (1:Hide-rox™ cookie:129)`
(3 pulls, for the two key lime pies and the grue egg omelette - this seems reasonable to me)

`sl_drunken = (1:splendid martini:50), (1:splendid martini:56), (1:splendid              martini:63), (1:Third Base:71), (1:oily mushroom wine:75), (1:oily mushroom wine:91), (1:oily mushroom wine:91), (1:jug of booze:124)`
(3 pulls for 3 oily mushroom wines - this is a little pricy and seems like not a great move. Decreasing the limit on cost-per-inebriety would mitigate this (since mushroom wines are expensive), or we could increase the penalty for "adventures from pulling" from -7 to -10 or something even larger.)

EDIT: Closes #308 (guards pullXWhenHaveY with "if we have one in storage already")