### PR TITLE
Presool: Change Order of Operations for equipping

### DIFF
--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -223,6 +223,25 @@ void handlePreAdventure(location place)
 		acquireMP(32, true);
 	}
 
+	foreach i,mon in get_monsters(place)
+	{
+		if(sl_wantToYellowRay(mon, place))
+		{
+			adjustForYellowRayIfPossible(mon);
+		}
+
+		if(sl_wantToBanish(mon, place))
+		{
+			adjustForBanishIfPossible(mon, place);
+		}
+	}
+
+	if(sl_latteDropWanted(place))
+	{
+		print('We want to get the "' + sl_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
+		slEquip($item[latte lovers member's mug]);
+	}
+
 	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))
 	{
 		if(!possessEquipment($item[Continuum Transfunctioner]))
@@ -244,25 +263,6 @@ void handlePreAdventure(location place)
 	if(place == $location[The Black Forest])
 	{
 		slEquip($slot[acc3], $item[Blackberry Galoshes]);
-	}
-
-	if(sl_latteDropWanted(place))
-	{
-		print('We want to get the "' + sl_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
-		slEquip($item[latte lovers member's mug]);
-	}
-
-	foreach i,mon in get_monsters(place)
-	{
-		if(sl_wantToYellowRay(mon, place))
-		{
-			adjustForYellowRayIfPossible(mon);
-		}
-
-		if(sl_wantToBanish(mon, place))
-		{
-			adjustForBanishIfPossible(mon, place);
-		}
 	}
 
 	bat_formPreAdventure();

--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -260,6 +260,15 @@ void handlePreAdventure(location place)
 		slEquip($slot[acc3], $item[Talisman O\' Namsilat]);
 	}
 
+	if((place == $location[The Haunted Wine Cellar]) && (my_turncount() != 0) && (get_property("sl_winebomb") == "partial"))
+	{
+		if(!possessEquipment($item[Unstable Fulminate]))
+		{
+			abort("Tried to charge a WineBomb but don't have one.");
+		}
+		slEquip($slot[acc3], $item[Unstable Fulminate]);
+	}
+
 	if(place == $location[The Black Forest])
 	{
 		slEquip($slot[acc3], $item[Blackberry Galoshes]);

--- a/RELEASE/scripts/presool.ash
+++ b/RELEASE/scripts/presool.ash
@@ -266,7 +266,7 @@ void handlePreAdventure(location place)
 		{
 			abort("Tried to charge a WineBomb but don't have one.");
 		}
-		slEquip($slot[acc3], $item[Unstable Fulminate]);
+		slEquip($slot[off-hand], $item[Unstable Fulminate]);
 	}
 
 	if(place == $location[The Black Forest])


### PR DESCRIPTION
Fixes issues where script equips banishers and latte AFTER required gear, and renders the user unable to adventure.

Also added an Unstable Fulminate Section to make perfectly sure we have it equipped before adventuring.