### PR TITLE
potion of temporary gr8ness rename fixes

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -1,6 +1,6 @@
 script "sl_ascend.ash";
 notify soolar the second;
-since r19375; // beach comb
+since r19482; // potion of temporary gr8ness rename
 /***
 	Killing is wrong, and bad. There should be a new, stronger word for killing like badwrong or badong. YES, killing is badong. From this moment, I will stand for the opposite of killing, gnodab.
 

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -3358,9 +3358,9 @@ void cs_make_stuff(int curQuest)
 				buffMaintain($effect[Inigo\'s Incantation of Inspiration], 100, 3, 25);
 			}
 
-			if((item_amount($item[gr8ps]) > 0) && (item_amount($item[Potion of Temporary Gr8tness]) == 0) && (npc_price($item[Delectable Catalyst]) < my_meat()) && ($classes[Sauceror, Pastamancer] contains my_class()) && (freeCrafts() > 0) && have_skill($skill[The Way of Sauce]))
+			if((item_amount($item[gr8ps]) > 0) && (item_amount($item[Potion of Temporary Gr8ness]) == 0) && (npc_price($item[Delectable Catalyst]) < my_meat()) && ($classes[Sauceror, Pastamancer] contains my_class()) && (freeCrafts() > 0) && have_skill($skill[The Way of Sauce]))
 			{
-				cli_execute("make " + $item[Potion of Temporary Gr8tness]);
+				cli_execute("make " + $item[Potion of Temporary Gr8ness]);
 			}
 			if((item_amount($item[grapefruit]) > 0) && (item_amount($item[Ointment of the Occult]) == 0) && (freeCrafts() > 0))
 			{
@@ -4391,7 +4391,7 @@ boolean cs_giant_growth()
 
 boolean sl_csHandleGrapes()
 {
-	if(item_amount($item[Potion of Temporary Gr8tness]) > 0)
+	if(item_amount($item[Potion of Temporary Gr8ness]) > 0)
 	{
 		return false;
 	}
@@ -4404,16 +4404,16 @@ boolean sl_csHandleGrapes()
 		useCocoon();
 		handleFaxMonster($monster[Sk8 gnome], "cs_combatYR");
 	}
-	if((item_amount($item[Gr8ps]) > 0) && (item_amount($item[Potion of Temporary Gr8tness]) == 0) && (have_effect($effect[Gr8tness]) == 0) && (npc_price($item[Delectable Catalyst]) < my_meat()) && (freeCrafts() > 0) && (item_amount($item[Scrumptious Reagent]) > 0) && have_skill($skill[Advanced Saucecrafting]) && ($classes[Pastamancer, Sauceror] contains my_class()) && have_skill($skill[The Way of Sauce]) && (sl_get_campground() contains $item[Dramatic&trade; Range]))
+	if((item_amount($item[Gr8ps]) > 0) && (item_amount($item[Potion of Temporary Gr8ness]) == 0) && (have_effect($effect[Gr8tness]) == 0) && (npc_price($item[Delectable Catalyst]) < my_meat()) && (freeCrafts() > 0) && (item_amount($item[Scrumptious Reagent]) > 0) && have_skill($skill[Advanced Saucecrafting]) && ($classes[Pastamancer, Sauceror] contains my_class()) && have_skill($skill[The Way of Sauce]) && (sl_get_campground() contains $item[Dramatic&trade; Range]))
 	{
 		if(!have_skills($skills[Expert Corner-Cutter, Rapid Prototyping]) && have_skill($skill[Inigo\'s Incantation of Inspiration]))
 		{
 			shrugAT($effect[Inigo\'s Incantation of Inspiration]);
 			buffMaintain($effect[Inigo\'s Incantation of Inspiration], 100, 1, 5);
 		}
-		cli_execute("make " + $item[Potion of Temporary Gr8tness]);
+		cli_execute("make " + $item[Potion of Temporary Gr8ness]);
 	}
-	return (item_amount($item[Potion of Temporary Gr8tness]) > 0);
+	return (item_amount($item[Potion of Temporary Gr8ness]) > 0);
 }
 
 int estimate_cs_questCost(int quest)

--- a/RELEASE/scripts/sl_ascend/sl_util.ash
+++ b/RELEASE/scripts/sl_ascend/sl_util.ash
@@ -4744,7 +4744,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Go Get \'Em\, Tiger!]:			useItem = $item[Ben-gal&trade; Balm];			break;
 	case $effect[Got Milk]:						useItem = $item[Milk of Magnesium];				break;
 	case $effect[Gothy]:						useItem = $item[Spooky Eyeliner];				break;
-	case $effect[Gr8tness]:						useItem = $item[Potion of Temporary Gr8tness];	break;
+	case $effect[Gr8tness]:						useItem = $item[Potion of Temporary Gr8ness];	break;
 	case $effect[Graham Crackling]:				useItem = $item[Heather Graham Cracker];		break;
 	case $effect[Greasy Peasy]:					useItem = $item[Robot Grease];					break;
 	case $effect[Greedy Resolve]:				useItem = $item[Resolution: Be Wealthier];		break;


### PR DESCRIPTION
Just removes the now extraneous 't' from the item name in a bunch of places and updates the mafia supported version accordingly.