### PR TITLE
Set CombBeach to use the free parameter

### DIFF
--- a/RELEASE/scripts/sl_ascend.ash
+++ b/RELEASE/scripts/sl_ascend.ash
@@ -2561,7 +2561,7 @@ boolean doBedtime()
 		}
 	}
 
-	cli_execute("CombBeach all");
+	cli_execute("CombBeach free");
 
 	# This does not check if we still want these buffs
 	if((my_hp() < (0.9 * my_maxhp())) && (get_property("_hotTubSoaks").to_int() < 5))


### PR DESCRIPTION
Test locally, adjusted from all to free as parameter based on CombBeach.ash as well as the usage in https://github.com/soolar/sl_ascend/blob/f5e159522f3c0f23f9409955aa39552c506f8616/RELEASE/scripts/sl_ascend/sl_mr2019.ash#L632

Would close #322 