### PR TITLE
CS efficiency: meteor shower + saber trick

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -704,7 +704,7 @@ int sl_meteorShowersUsed();                     //Defined in sl_ascend/sl_mr2017
 int sl_meteorShowersAvailable();                //Defined in sl_ascend/sl_mr2017.ash
 int sl_macroMeteoritesUsed();                   //Defined in sl_ascend/sl_mr2017.ash
 int sl_macrometeoritesAvailable();              //Defined in sl_ascend/sl_mr2017.ash
-int sl_meteoriteAdesUsed()();                   //Defined in sl_ascend/sl_mr2017.ash
+int sl_meteoriteAdesUsed();                   //Defined in sl_ascend/sl_mr2017.ash
 boolean handleBarrelFullOfBarrels(boolean daily);			//Defined in sl_ascend/sl_util.ash
 boolean handleCopiedMonster(item itm);						//Defined in sl_ascend/sl_util.ash
 boolean handleCopiedMonster(item itm, string option);		//Defined in sl_ascend/sl_util.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -418,6 +418,7 @@ boolean sl_change_mcd(int mcd);								//Defined in sl_ascend/sl_util.ash
 string sl_combatHandler(int round, string opp, string text);//Defined in sl_ascend/sl_combat.ash
 boolean sl_doPrecinct();									//Defined in sl_ascend/sl_mr2016.ash
 string sl_edCombatHandler(int round, string opp, string text);//Defined in sl_ascend/sl_combat.ash
+string sl_saberTrickMeteorShowerCombatHandler(int round, string opp, string text); //Defined in sl_ascend/sl_combat.ash
 boolean sl_floundryAction();								//Defined in sl_ascend/sl_clan.ash
 boolean sl_floundryUse();									//Defined in sl_ascend/sl_clan.ash
 boolean sl_floundryAction(item it);							//Defined in sl_ascend/sl_clan.ash
@@ -483,6 +484,8 @@ boolean do_cs_quest(int quest);								//Defined in sl_ascend/sl_community_servi
 boolean do_cs_quest(string quest);							//Defined in sl_ascend/sl_community_service.ash
 boolean cs_preTurnStuff(int curQuest);						//Defined in sl_ascend/sl_community_service.ash
 void set_cs_questListFast(int[int] fast);					//Defined in sl_ascend/sl_community_service.ash
+boolean canTrySaberTrickMeteorShower();           //Defined in sl_ascend/sl_community_service.ash
+boolean trySaberTrickMeteorShower();              //Defined in sl_ascend/sl_community_service.ash
 
 boolean dealWithMilkOfMagnesium(boolean useAdv);			//Defined in sl_ascend/sl_cooking.ash
 void debugMaximize(string req, int meat);					//Defined in sl_ascend/sl_util.ash
@@ -697,6 +700,11 @@ boolean makeGeniePocket();									//Defined in sl_ascend/sl_mr2017.ash
 boolean spacegateVaccineAvailable();						//Defined in sl_ascend/sl_mr2017.ash
 boolean spacegateVaccineAvailable(effect ef);				//Defined in sl_ascend/sl_mr2017.ash
 boolean spacegateVaccine(effect ef);						//Defined in sl_ascend/sl_mr2017.ash
+int sl_meteorShowersUsed();                     //Defined in sl_ascend/sl_mr2017.ash
+int sl_meteorShowersAvailable();                //Defined in sl_ascend/sl_mr2017.ash
+int sl_macroMeteoritesUsed();                   //Defined in sl_ascend/sl_mr2017.ash
+int sl_macrometeoritesAvailable();              //Defined in sl_ascend/sl_mr2017.ash
+int sl_meteoriteAdesUsed()();                   //Defined in sl_ascend/sl_mr2017.ash
 boolean handleBarrelFullOfBarrels(boolean daily);			//Defined in sl_ascend/sl_util.ash
 boolean handleCopiedMonster(item itm);						//Defined in sl_ascend/sl_util.ash
 boolean handleCopiedMonster(item itm, string option);		//Defined in sl_ascend/sl_util.ash
@@ -1087,4 +1095,3 @@ location[int] zones_available();							//Defined in sl_ascend/sl_zone.ash
 monster[int] mobs_available();								//Defined in sl_ascend/sl_zone.ash
 item[int] drops_available();								//Defined in sl_ascend/sl_zone.ash
 item[int] hugpocket_available();							//Defined in sl_ascend/sl_zone.ash
-

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -727,7 +727,7 @@ string sl_combatHandler(int round, string opp, string text)
 			return "item " + $item[Power Pill];
 		}
 	}
-	
+
 	if((my_familiar() == $familiar[Pair of Stomping Boots]) && (get_property("_bootStomps").to_int()) < 7 && instakillable(enemy) && get_property("bootsCharged").to_boolean())
 	{
 		if(!($monsters[Dairy Goat, Lobsterfrogman, Writing Desk] contains enemy) && !($locations[The Laugh Floor, Infernal Rackets Backstage] contains my_location())  )
@@ -3319,7 +3319,16 @@ string sl_edCombatHandler(int round, string opp, string text)
 	return "skill " + $skill[Mild Curse];
 }
 
-
+string sl_saberTrickMeteorShowerCombatHandler(int round, string opp, string text){
+	if(canUse($skill[Use the Force]) && sl_saberChargesAvailable() > 0 && sl_have_skill($skill[Meteor Lore])){
+		if(canUse($skill[Meteor Shower])){
+			return useSkill($skill[Meteor Shower]));
+		} else {
+			return sl_combatSaberYR();
+		}
+	}
+	abort("Unable to perform saber trick (meteor shower)");
+}
 
 monster ocrs_helper(string page)
 {

--- a/RELEASE/scripts/sl_ascend/sl_combat.ash
+++ b/RELEASE/scripts/sl_ascend/sl_combat.ash
@@ -3322,12 +3322,13 @@ string sl_edCombatHandler(int round, string opp, string text)
 string sl_saberTrickMeteorShowerCombatHandler(int round, string opp, string text){
 	if(canUse($skill[Use the Force]) && sl_saberChargesAvailable() > 0 && sl_have_skill($skill[Meteor Lore])){
 		if(canUse($skill[Meteor Shower])){
-			return useSkill($skill[Meteor Shower]));
+			return useSkill($skill[Meteor Shower]);
 		} else {
 			return sl_combatSaberYR();
 		}
 	}
 	abort("Unable to perform saber trick (meteor shower)");
+	return "";
 }
 
 monster ocrs_helper(string page)

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -1931,6 +1931,9 @@ boolean LA_cs_communityService()
 			{
 				currentCost = currentCost - 1;
 			}
+			if(canTrySaberTrickMeteorShower()){
+				currentCost = currentCost - 4;
+			}
 
 			int needCost = lastQuestCost + currentCost;
 
@@ -2021,6 +2024,9 @@ boolean LA_cs_communityService()
 			if(is_unrestricted($item[Clan Pool Table]) && (have_effect($effect[Billiards Belligerence]) == 0))
 			{
 				visit_url("clan_viplounge.php?preaction=poolgame&stance=1");
+			}
+			if(canTrySaberTrickMeteorShower() && have_effect($effect[Meteor Showered]) == 0){
+				trySaberTrickMeteorShower();
 			}
 
 			familiar toFam = $familiar[Cocoabo];
@@ -2167,6 +2173,10 @@ boolean LA_cs_communityService()
 				}
 			}
 
+			if(canTrySaberTrickMeteorShower() && have_effect($effect[Meteor Showered]) == 0){
+				trySaberTrickMeteorShower();
+			}
+
 			if(do_cs_quest(6))
 			{
 				curQuest = 0;
@@ -2232,6 +2242,10 @@ boolean LA_cs_communityService()
 					restoreSetting("choiceAdventure1119");
 					set_property("choiceAdventure1119", "");
 					return true;
+				}
+
+				if(canTrySaberTrickMeteorShower() && have_effect($effect[Meteor Showered]) == 0){
+					trySaberTrickMeteorShower();
 				}
 
 				if((have_effect($effect[Half-Blooded]) > 0) || (have_effect($effect[Half-Drained]) > 0) || (have_effect($effect[Bruised]) > 0) || (have_effect($effect[Relaxed Muscles]) > 0) || (have_effect($effect[Hypnotized]) > 0) || (have_effect($effect[Bad Haircut]) > 0))
@@ -4932,4 +4946,26 @@ boolean cs_preTurnStuff(int curQuest)
 	LX_dolphinKingMap();
 
 	return false;
+}
+
+boolean canTrySaberTrickMeteorShower(){
+	if(sl_meteorShowersAvailable() == 0 || sl_saberChargesAvailable() == 0){
+		return false
+	}
+
+	return true;
+}
+
+// use meteor shower in combat, then cosplay saber to flee and keep the buff (+200% weapon/spell dmg and +20 lb familiar)
+boolean trySaberTrickMeteorShower(){
+	if(!canTrySaberTrickMeteorShower()){
+		return false
+	}
+
+	if(equipped_amount($item[Fourth of May Cosplay Saber]) == 0 && !slEquip($item[Fourth of May Cosplay Saber])){
+		return false
+	}
+
+	//saber should be equipped with use the force and meteorshower charges available
+	return slAdv(1, $location[The Dire Warren], "sl_saberTrickMeteorShowerCombatHandler");
 }

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -4962,10 +4962,13 @@ boolean trySaberTrickMeteorShower(){
 		return false;
 	}
 
-	if(equipped_amount($item[Fourth of May Cosplay Saber]) == 0 && !slEquip($item[Fourth of May Cosplay Saber])){
+	// force equip so maximizer in presool doesnt accidentally remove it
+	if(!slForceEquip($item[Fourth of May Cosplay Saber])){
 		return false;
 	}
 
 	//saber should be equipped with use the force and meteorshower charges available
-	return slAdv(1, $location[The Dire Warren], "sl_saberTrickMeteorShowerCombatHandler");
+	boolean ret = slAdv(1, $location[The Dire Warren], "sl_saberTrickMeteorShowerCombatHandler");
+	resetMaximize();
+	return ret;
 }

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -4950,7 +4950,7 @@ boolean cs_preTurnStuff(int curQuest)
 
 boolean canTrySaberTrickMeteorShower(){
 	if(sl_meteorShowersAvailable() == 0 || sl_saberChargesAvailable() == 0){
-		return false
+		return false;
 	}
 
 	return true;
@@ -4959,11 +4959,11 @@ boolean canTrySaberTrickMeteorShower(){
 // use meteor shower in combat, then cosplay saber to flee and keep the buff (+200% weapon/spell dmg and +20 lb familiar)
 boolean trySaberTrickMeteorShower(){
 	if(!canTrySaberTrickMeteorShower()){
-		return false
+		return false;
 	}
 
 	if(equipped_amount($item[Fourth of May Cosplay Saber]) == 0 && !slEquip($item[Fourth of May Cosplay Saber])){
-		return false
+		return false;
 	}
 
 	//saber should be equipped with use the force and meteorshower charges available

--- a/RELEASE/scripts/sl_ascend/sl_mr2017.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2017.ash
@@ -1807,3 +1807,31 @@ boolean spacegateVaccine(effect ef)
 	cli_execute("spacegate vaccine " + i);
 	return true;
 }
+
+int sl_meteorShowersUsed(){
+	return get_property("_meteorShowerUses").to_int();
+}
+
+int sl_meteorShowersAvailable(){
+	if(!is_unrestricted($skill[Meteor Lore]) || !have_skill($skill[Meteor Lore])){
+		return 0;
+	}
+
+	return 5 - sl_meteorShowersUsed();
+}
+
+int sl_macroMeteoritesUsed(){
+	return get_property("_macrometeoriteUses").to_int();
+}
+
+int sl_macrometeoritesAvailable(){
+	if(!is_unrestricted($skill[Meteor Lore]) || !have_skill($skill[Meteor Lore])){
+		return 0;
+	}
+
+	return 10 - sl_macroMeteoritesUsed();
+}
+
+int sl_meteoriteAdesUsed(){
+	return get_property("_meteoriteAdesUsed").to_int();
+}


### PR DESCRIPTION
If able, uses meteor shower + saber to gain the Meteor Showered effect (+200% weapon damage, +200% spell damage, +20 familiar weight) before doing the community service tasks associated with this attributes. Should save ~12 adventures and both skills are under utilized in CS runs. 

Also adds common methods and shows a pattern for using this in other areas of sl_ascend if others are inclined to implement it.